### PR TITLE
Fix local Zotero citation exports

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -320,28 +320,40 @@ def _xhtml_to_text(fragment: str) -> str:
     return " ".join(html.unescape(text).split())
 
 
-def _fetch_item_export(
+def _fetch_item_exports(
     item_key: str,
     *,
-    content: str,
     style: str,
     locale: str,
-) -> str:
-    """Fetch one formatted export block for a Zotero item."""
+) -> dict[str, str]:
+    """Fetch formatted citation, bibliography, and BibTeX blocks for one item."""
     zot = _get_zot()
     exported = zot.item(
         item_key,
-        format="atom",
-        content=content,
+        format="json",
+        include="bib,citation,bibtex",
         style=style,
         locale=locale,
     )
 
-    if isinstance(exported, list):
-        return exported[0] if exported else ""
-    if isinstance(exported, str):
-        return exported
-    return ""
+    if not isinstance(exported, dict):
+        raise TypeError(f"Unexpected export payload: {type(exported).__name__}")
+
+    data = exported.get("data", {}) if isinstance(exported.get("data"), dict) else {}
+
+    def _get_export_block(name: str) -> str:
+        value = exported.get(name, data.get(name, ""))
+        if isinstance(value, list):
+            return value[0] if value else ""
+        if isinstance(value, str):
+            return value
+        return ""
+
+    return {
+        "citation": _get_export_block("citation"),
+        "bibliography": _get_export_block("bib"),
+        "bibtex": _get_export_block("bibtex"),
+    }
 
 
 def _ensure_sidecar_layout() -> None:
@@ -1809,30 +1821,13 @@ def get_bibtex_and_citation_for_items(
 
     for key in requested_keys:
         try:
-            citation = _fetch_item_export(
-                key,
-                content="citation",
-                style=style,
-                locale=locale,
-            )
-            bibliography = _fetch_item_export(
-                key,
-                content="bib",
-                style=style,
-                locale=locale,
-            )
-            bibtex = _fetch_item_export(
-                key,
-                content="bibtex",
-                style=style,
-                locale=locale,
-            )
+            exports = _fetch_item_exports(key, style=style, locale=locale)
 
             results.append({
                 "key": key,
-                "citation": _xhtml_to_text(citation),
-                "bibliography": _xhtml_to_text(bibliography),
-                "bibtex": bibtex.strip(),
+                "citation": _xhtml_to_text(exports["citation"]),
+                "bibliography": _xhtml_to_text(exports["bibliography"]),
+                "bibtex": exports["bibtex"].strip(),
             })
         except Exception as exc:
             errors.append({

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -750,17 +750,16 @@ class CitationEntryTests(DbTestCase):
         zot = Mock()
 
         def item_side_effect(item_key, **kwargs):
-            self.assertEqual(kwargs["format"], "atom")
+            self.assertEqual(kwargs["format"], "json")
+            self.assertEqual(kwargs["include"], "bib,citation,bibtex")
             self.assertEqual(kwargs["style"], "apa")
             self.assertEqual(kwargs["locale"], "fr-FR")
 
-            content = kwargs["content"]
-            values = {
+            return {
                 "citation": [f"<span>{item_key} &amp; cite</span>"],
                 "bib": [f"<div>{item_key} <i>reference</i></div>"],
                 "bibtex": [f"@article{{{item_key},\n  title={{Example}}\n}}"],
             }
-            return values[content]
 
         zot.item.side_effect = item_side_effect
 
@@ -796,14 +795,13 @@ class CitationEntryTests(DbTestCase):
             if item_key == "BADKEY":
                 raise RuntimeError("missing item")
 
-            content = kwargs["content"]
-            if content == "citation":
-                return [f"<span>{item_key} cite</span>"]
-            if content == "bib":
-                return [f"<div>{item_key} ref</div>"]
-            if content == "bibtex":
-                return [f"@article{{{item_key}}}"]
-            raise AssertionError(f"Unexpected content: {content}")
+            self.assertEqual(kwargs["format"], "json")
+            self.assertEqual(kwargs["include"], "bib,citation,bibtex")
+            return {
+                "citation": [f"<span>{item_key} cite</span>"],
+                "bib": [f"<div>{item_key} ref</div>"],
+                "bibtex": [f"@article{{{item_key}}}"],
+            }
 
         zot.item.side_effect = item_side_effect
 


### PR DESCRIPTION
Use the local Zotero JSON export path for citation, bibliography, and BibTeX retrieval instead of requesting Atom output, which the local API rejects with 501.

Closes #4