### PR TITLE
Fix invalid collection keys in list_collection_items

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -1762,20 +1762,61 @@ def list_collections() -> str:
 def list_collection_items(collection_key: str, limit: int = 50) -> str:
     """Return items in a specific collection."""
     limit = max(1, limit)
+    normalized_collection_key = collection_key.strip().upper()
+    if not normalized_collection_key:
+        return json.dumps({
+            "collection_key": "",
+            "collection_found": False,
+            "items": [],
+            "total": 0,
+            "error": "Provide collection_key",
+        })
+
     try:
         zot = _get_zot()
-        items = zot.collection_items(collection_key, limit=limit)
+        collections = zot.collections()
+        collection_found = any(
+            collection.get("data", {}).get("key", "").upper() == normalized_collection_key
+            for collection in collections
+        )
+        if not collection_found:
+            return json.dumps({
+                "collection_key": normalized_collection_key,
+                "collection_found": False,
+                "items": [],
+                "total": 0,
+                "error": f"Collection {normalized_collection_key} was not found",
+            })
+        items = zot.collection_items(normalized_collection_key, limit=limit)
     except Exception as exc:
-        return json.dumps({"error": f"Failed to fetch collection items: {exc}"})
+        return json.dumps({
+            "collection_key": normalized_collection_key,
+            "collection_found": False,
+            "items": [],
+            "total": 0,
+            "error": f"Failed to fetch collection items: {exc}",
+        })
 
     result = []
     for item in items:
         data = item.get("data", {})
         if data.get("itemType") in ("attachment", "note"):
             continue
+        item_collections = {
+            key.upper()
+            for key in data.get("collections", [])
+            if isinstance(key, str)
+        }
+        if normalized_collection_key not in item_collections:
+            continue
         result.append(_item_to_dict(item, truncate_abstract=500))
 
-    return json.dumps({"items": result, "total": len(result)})
+    return json.dumps({
+        "collection_key": normalized_collection_key,
+        "collection_found": True,
+        "items": result,
+        "total": len(result),
+    })
 
 
 def get_item(item_key: str) -> str:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -211,6 +211,84 @@ class AttachmentPathsTests(DbTestCase):
         self.assertEqual(result["results"][0]["snippet_attachment_key"], "ATTACH1")
 
 
+class CollectionItemTests(DbTestCase):
+    def test_list_collection_items_returns_structured_error_for_invalid_key(self):
+        zot = Mock()
+        zot.collections.return_value = [
+            {"data": {"key": "COLL123", "name": "Valid Collection"}}
+        ]
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.list_collection_items("missing"))
+
+        self.assertEqual(result["collection_key"], "MISSING")
+        self.assertFalse(result["collection_found"])
+        self.assertEqual(result["items"], [])
+        self.assertEqual(result["total"], 0)
+        self.assertIn("not found", result["error"])
+        zot.collection_items.assert_not_called()
+
+    def test_list_collection_items_returns_structured_filtered_items_for_valid_key(self):
+        zot = Mock()
+        zot.collections.return_value = [
+            {"data": {"key": "COLL123", "name": "Valid Collection"}}
+        ]
+        zot.collection_items.return_value = [
+            {
+                "data": {
+                    "key": "ITEM1",
+                    "itemType": "preprint",
+                    "title": "First Paper",
+                    "creators": [{"firstName": "Jane", "lastName": "Example"}],
+                    "date": "2026-03-10",
+                    "DOI": "10.1000/one",
+                    "url": "https://example.org/one",
+                    "tags": [{"tag": "chemistry"}],
+                    "collections": ["COLL123"],
+                    "abstractNote": "First abstract.",
+                }
+            },
+            {
+                "data": {
+                    "key": "ITEM2",
+                    "itemType": "preprint",
+                    "title": "Wrong Collection",
+                    "creators": [{"firstName": "John", "lastName": "Example"}],
+                    "date": "2026-03-11",
+                    "DOI": "10.1000/two",
+                    "url": "https://example.org/two",
+                    "tags": [],
+                    "collections": ["OTHER"],
+                    "abstractNote": "Second abstract.",
+                }
+            },
+            {
+                "data": {
+                    "key": "ATTACH1",
+                    "itemType": "attachment",
+                    "title": "Attachment",
+                    "creators": [],
+                    "date": "",
+                    "DOI": "",
+                    "url": "",
+                    "tags": [],
+                    "collections": ["COLL123"],
+                    "abstractNote": "",
+                }
+            },
+        ]
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.list_collection_items("coll123", limit=5))
+
+        self.assertEqual(result["collection_key"], "COLL123")
+        self.assertTrue(result["collection_found"])
+        self.assertEqual(result["total"], 1)
+        self.assertEqual([row["key"] for row in result["items"]], ["ITEM1"])
+        self.assertEqual(result["items"][0]["title"], "First Paper")
+        zot.collection_items.assert_called_once_with("COLL123", limit=5)
+
+
 class SearchBehaviorTests(DbTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Fix issue #17 by validating collection keys before listing items and returning a structured JSON result with \collection_found\ and \error\ fields when the key is invalid. This also filters returned items against the requested collection key so a bad response cannot silently leak the wrong dataset.\n\nTests: uv run python -m unittest tests.test_db tests.test_server; make test\n\nCloses #17