### PR TITLE
Fix #24: filter annotation items from collection listings

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -1860,7 +1860,7 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
     result = []
     for item in items:
         data = item.get("data", {})
-        if data.get("itemType") in ("attachment", "note"):
+        if data.get("itemType") in _SKIP_TYPES:
             continue
         item_collections = {
             key.upper()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -297,6 +297,20 @@ class CollectionItemTests(DbTestCase):
                     "abstractNote": "",
                 }
             },
+            {
+                "data": {
+                    "key": "ANNOT1",
+                    "itemType": "annotation",
+                    "title": "Annotation",
+                    "creators": [],
+                    "date": "",
+                    "DOI": "",
+                    "url": "",
+                    "tags": [],
+                    "collections": ["COLL123"],
+                    "abstractNote": "",
+                }
+            },
         ]
 
         with patch("zoty.db._get_zot", return_value=zot):


### PR DESCRIPTION
## Summary
- use `_SKIP_TYPES` when filtering `list_collection_items`
- add a regression case showing annotation items are excluded from collection results

## Testing
- `uv run python -m unittest tests.test_db -v`

Closes #24
