### PR TITLE
fix(search): normalize duplicated indexed dates

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -155,6 +155,22 @@ def _normalize_plain_text(text: str) -> str:
     return " ".join(text.split())
 
 
+def _normalize_item_date(value: str) -> str:
+    normalized = " ".join(value.split())
+    if not normalized:
+        return ""
+
+    parts = normalized.split(" ")
+    if (
+        len(parts) == 2
+        and parts[0] == parts[1]
+        and re.fullmatch(r"\d{4}-\d{2}-\d{2}", parts[0]) is not None
+    ):
+        return parts[0]
+
+    return normalized
+
+
 def _extract_query_terms(query: str) -> list[str]:
     return re.findall(r"(?u)\b\w\w+\b", query.lower())
 
@@ -587,7 +603,7 @@ def _fetch_parent_records() -> dict[str, _ParentRecord]:
             elif field_name == "abstractNote":
                 parent.abstract = value
             elif field_name == "date":
-                parent.date = value
+                parent.date = _normalize_item_date(value)
             elif field_name == "DOI":
                 parent.doi = value
             elif field_name == "url":

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -310,6 +310,116 @@ class CollectionItemTests(DbTestCase):
         zot.collection_items.assert_called_once_with("COLL123", limit=5)
 
 
+class ParentRecordDateNormalizationTests(DbTestCase):
+    def setUp(self):
+        super().setUp()
+        with closing(sqlite3.connect(db._ZOTERO_DB)) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE items (
+                    itemID INTEGER PRIMARY KEY,
+                    key TEXT NOT NULL,
+                    version INTEGER,
+                    dateModified TEXT,
+                    itemTypeID INTEGER NOT NULL,
+                    libraryID INTEGER
+                );
+                CREATE TABLE itemTypesCombined (
+                    itemTypeID INTEGER PRIMARY KEY,
+                    typeName TEXT NOT NULL
+                );
+                CREATE TABLE deletedItems (
+                    itemID INTEGER PRIMARY KEY
+                );
+                CREATE TABLE fields (
+                    fieldID INTEGER PRIMARY KEY,
+                    fieldName TEXT NOT NULL
+                );
+                CREATE TABLE itemDataValues (
+                    valueID INTEGER PRIMARY KEY,
+                    value TEXT UNIQUE
+                );
+                CREATE TABLE itemData (
+                    itemID INTEGER NOT NULL,
+                    fieldID INTEGER NOT NULL,
+                    valueID INTEGER NOT NULL
+                );
+                CREATE TABLE itemCreators (
+                    itemID INTEGER NOT NULL,
+                    creatorID INTEGER NOT NULL,
+                    orderIndex INTEGER NOT NULL
+                );
+                CREATE TABLE creators (
+                    creatorID INTEGER PRIMARY KEY,
+                    firstName TEXT,
+                    lastName TEXT,
+                    fieldMode INTEGER
+                );
+                CREATE TABLE collectionItems (
+                    collectionID INTEGER NOT NULL,
+                    itemID INTEGER NOT NULL,
+                    orderIndex INTEGER NOT NULL
+                );
+                CREATE TABLE collections (
+                    collectionID INTEGER PRIMARY KEY,
+                    key TEXT NOT NULL
+                );
+                CREATE TABLE itemTags (
+                    itemID INTEGER NOT NULL,
+                    tagID INTEGER NOT NULL
+                );
+                CREATE TABLE tags (
+                    tagID INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL
+                );
+                """
+            )
+            conn.execute(
+                """INSERT INTO itemTypesCombined(itemTypeID, typeName)
+                   VALUES (?, ?)""",
+                (1, "preprint"),
+            )
+            conn.execute(
+                """INSERT INTO items(itemID, key, version, dateModified, itemTypeID, libraryID)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (1, "PARENT1", 3, "2026-03-10 10:00:00", 1, 1),
+            )
+            conn.executemany(
+                "INSERT INTO fields(fieldID, fieldName) VALUES (?, ?)",
+                [
+                    (1, "title"),
+                    (2, "date"),
+                ],
+            )
+            conn.executemany(
+                "INSERT INTO itemDataValues(valueID, value) VALUES (?, ?)",
+                [
+                    (1, "Normalized Date Paper"),
+                    (2, "2025-09-17 2025-09-17"),
+                ],
+            )
+            conn.executemany(
+                "INSERT INTO itemData(itemID, fieldID, valueID) VALUES (?, ?, ?)",
+                [
+                    (1, 1, 1),
+                    (1, 2, 2),
+                ],
+            )
+            conn.commit()
+
+    def test_normalize_item_date_collapses_duplicate_iso_dates_only(self):
+        self.assertEqual(db._normalize_item_date("2025-09-17 2025-09-17"), "2025-09-17")
+        self.assertEqual(db._normalize_item_date(" 2025-09-17   2025-09-17 "), "2025-09-17")
+        self.assertEqual(db._normalize_item_date("2025-09-17 2025-10-01"), "2025-09-17 2025-10-01")
+        self.assertEqual(db._normalize_item_date("Spring 2025 Spring 2025"), "Spring 2025 Spring 2025")
+
+    def test_fetch_parent_records_normalizes_duplicated_date_field(self):
+        parents = db._fetch_parent_records()
+
+        self.assertEqual(parents["PARENT1"].date, "2025-09-17")
+        self.assertEqual(parents["PARENT1"].title, "Normalized Date Paper")
+
+
 class SearchBehaviorTests(DbTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Summary
- normalize duplicated ISO-style Zotero date strings when loading parent metadata from the sidecar SQLite source
- preserve non-duplicated dates and free-form date text so only the malformed repeated-date case is collapsed
- add regression tests for both the helper and the SQLite-backed parent record loader

## Testing
- `make test`

Closes #16
