### PR TITLE
Fix oversized creator lists in list/search responses

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -38,6 +38,7 @@ _CACHE_CONTENT_TYPES = {
 _CHUNK_WORDS = 200
 _CHUNK_OVERLAP_WORDS = 40
 _SEARCH_RESULT_LIMIT_CAP = 25
+_LIST_VIEW_MAX_CREATORS = 5
 
 @dataclass
 class _ParentRecord:
@@ -133,6 +134,16 @@ def _format_creators(creators: list[dict]) -> list[str]:
         elif name:
             names.append(name)
     return names
+
+
+def _truncate_creator_names(creators: list[str], *, max_creators: int = _LIST_VIEW_MAX_CREATORS) -> list[str]:
+    """Keep list/search payloads compact by capping long author lists."""
+    if max_creators < 0 or len(creators) <= max_creators:
+        return list(creators)
+
+    truncated = list(creators[:max_creators])
+    truncated.append(f"... and {len(creators) - max_creators} more")
+    return truncated
 
 
 def _json_dumps(value: Any) -> str:
@@ -291,6 +302,7 @@ def _item_to_dict(
     truncate_abstract: int = 0,
     *,
     include_attachments: bool = False,
+    max_creators: int = -1,
 ) -> dict:
     """Convert a pyzotero item to a concise dict for tool output."""
     data = item.get("data", {})
@@ -305,7 +317,10 @@ def _item_to_dict(
         "key": data.get("key", ""),
         "itemType": data.get("itemType", ""),
         "title": data.get("title", ""),
-        "creators": _format_creators(data.get("creators", [])),
+        "creators": _truncate_creator_names(
+            _format_creators(data.get("creators", [])),
+            max_creators=max_creators,
+        ),
         "date": data.get("date", ""),
         "DOI": data.get("DOI", ""),
         "url": data.get("url", ""),
@@ -1478,7 +1493,7 @@ def _result_from_parent(
         "key": parent["key"],
         "itemType": parent["itemType"],
         "title": parent["title"],
-        "creators": list(parent["creators"]),
+        "creators": _truncate_creator_names(parent["creators"]),
         "date": parent["date"],
         "DOI": parent["DOI"],
         "url": parent["url"],
@@ -1530,7 +1545,7 @@ def _item_summary_from_parent(parent: dict[str, Any]) -> dict[str, Any]:
         "key": parent["key"],
         "itemType": parent["itemType"],
         "title": parent["title"],
-        "creators": list(parent["creators"]),
+        "creators": _truncate_creator_names(parent["creators"]),
         "date": parent["date"],
         "DOI": parent["DOI"],
         "url": parent["url"],
@@ -1869,7 +1884,7 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
         }
         if normalized_collection_key not in item_collections:
             continue
-        result.append(_item_to_dict(item, truncate_abstract=500))
+        result.append(_item_to_dict(item, truncate_abstract=500, max_creators=_LIST_VIEW_MAX_CREATORS))
 
     return json.dumps({
         "collection_key": normalized_collection_key,
@@ -1957,5 +1972,8 @@ def get_recent_items(limit: int = 10) -> str:
     except Exception as exc:
         return json.dumps({"error": f"Failed to fetch recent items: {exc}"})
 
-    result = [_item_to_dict(item, truncate_abstract=500) for item in items]
+    result = [
+        _item_to_dict(item, truncate_abstract=500, max_creators=_LIST_VIEW_MAX_CREATORS)
+        for item in items
+    ]
     return json.dumps({"items": result, "total": len(result)})

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -79,6 +79,12 @@ class DbTestCase(unittest.TestCase):
             }
         }
 
+    def _creator_dicts(self, count: int) -> list[dict[str, str]]:
+        return [
+            {"firstName": f"Author{index + 1}", "lastName": "Example"}
+            for index in range(count)
+        ]
+
     def _install_search_state(self, docs, *, parents=None):
         if parents is None:
             parents = {
@@ -193,6 +199,19 @@ class AttachmentPathsTests(DbTestCase):
         self.assertEqual(result["key"], "PARENT1")
         self.assertEqual(result["attachments"][0]["filepath"], str(db._ZOTERO_STORAGE / "ATTACH1" / "paper.pdf"))
         self.assertEqual(result["attachments"][0]["contentType"], "application/pdf")
+
+    def test_get_item_preserves_full_creator_list(self):
+        zot = Mock()
+        item = self._paper_item()
+        item["data"]["creators"] = self._creator_dicts(7)
+        zot.item.return_value = item
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.get_item("PARENT1"))
+
+        self.assertEqual(len(result["creators"]), 7)
+        self.assertEqual(result["creators"][0], "Author1 Example")
+        self.assertEqual(result["creators"][-1], "Author7 Example")
 
     def test_get_item_rejects_empty_item_key(self):
         with patch("zoty.db._get_zot") as get_zot_mock:
@@ -309,6 +328,67 @@ class CollectionItemTests(DbTestCase):
         self.assertEqual(result["items"][0]["title"], "First Paper")
         zot.collection_items.assert_called_once_with("COLL123", limit=5)
 
+    def test_list_collection_items_truncates_long_creator_lists(self):
+        zot = Mock()
+        zot.collections.return_value = [
+            {"data": {"key": "COLL123", "name": "Valid Collection"}}
+        ]
+        zot.collection_items.return_value = [
+            {
+                "data": {
+                    "key": "ITEM1",
+                    "itemType": "preprint",
+                    "title": "First Paper",
+                    "creators": self._creator_dicts(7),
+                    "date": "2026-03-10",
+                    "DOI": "10.1000/one",
+                    "url": "https://example.org/one",
+                    "tags": [{"tag": "chemistry"}],
+                    "collections": ["COLL123"],
+                    "abstractNote": "First abstract.",
+                }
+            },
+        ]
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.list_collection_items("coll123", limit=5))
+
+        self.assertEqual(
+            result["items"][0]["creators"],
+            [
+                "Author1 Example",
+                "Author2 Example",
+                "Author3 Example",
+                "Author4 Example",
+                "Author5 Example",
+                "... and 2 more",
+            ],
+        )
+
+
+class RecentItemsTests(DbTestCase):
+    def test_get_recent_items_truncates_long_creator_lists(self):
+        zot = Mock()
+        item = self._paper_item()
+        item["data"]["creators"] = self._creator_dicts(8)
+        zot.items.return_value = [item]
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.get_recent_items(limit=1))
+
+        self.assertEqual(result["total"], 1)
+        self.assertEqual(
+            result["items"][0]["creators"],
+            [
+                "Author1 Example",
+                "Author2 Example",
+                "Author3 Example",
+                "Author4 Example",
+                "Author5 Example",
+                "... and 3 more",
+            ],
+        )
+
 
 class SearchBehaviorTests(DbTestCase):
     def setUp(self):
@@ -405,6 +485,50 @@ class SearchBehaviorTests(DbTestCase):
         self.assertEqual(result["results"][0]["key"], "PARENT1")
         self.assertIn("meatpotatoes", result["results"][0]["snippet"].lower())
         self.assertEqual(result["results"][0]["snippet_attachment_key"], "ATTACH1")
+
+    def test_search_truncates_long_creator_lists(self):
+        attachment_doc = {
+            "doc_id": "chunk:ATTACH1:0",
+            "parent_key": "PARENT1",
+            "attachment_key": "ATTACH1",
+            "doc_kind": "attachment_chunk",
+            "chunk_index": 0,
+            "char_start": 0,
+            "char_end": 80,
+            "token_count": 12,
+            "text": "This body text contains meatpotatoes evidence deep in the paper body.",
+            "text_hash": "hash-body",
+        }
+        parents = {
+            "PARENT1": {
+                "key": "PARENT1",
+                "dateModified": "2026-03-10 10:00:00",
+                "itemType": "preprint",
+                "title": "Example Paper",
+                "abstract": "Example abstract.",
+                "creators": [f"Author {index + 1}" for index in range(7)],
+                "collections": ["COLL123"],
+                "tags": ["chemistry"],
+                "date": "2026-03-10",
+                "DOI": "10.1000/example",
+                "url": "https://example.org/paper",
+            }
+        }
+        self._install_search_state([(attachment_doc, 7.25)], parents=parents)
+
+        result = json.loads(db.search("meatpotatoes"))
+
+        self.assertEqual(
+            result["results"][0]["creators"],
+            [
+                "Author 1",
+                "Author 2",
+                "Author 3",
+                "Author 4",
+                "Author 5",
+                "... and 2 more",
+            ],
+        )
 
     def test_metadata_query_uses_abstract_snippet_without_attachment_key(self):
         metadata_doc = {
@@ -706,6 +830,52 @@ class SearchBehaviorTests(DbTestCase):
         self.assertEqual(result["results"][0]["attachment_key"], "ATTACH1")
         self.assertEqual(result["results"][1]["attachment_key"], "ATTACH2")
         self.assertNotIn("attachment_key", result["results"][2])
+
+    def test_search_within_item_truncates_item_creator_list(self):
+        parents = {
+            "PARENT1": {
+                "key": "PARENT1",
+                "dateModified": "2026-03-10 10:00:00",
+                "itemType": "preprint",
+                "title": "First Paper",
+                "abstract": "First abstract with metadata match.",
+                "creators": [f"Author {index + 1}" for index in range(8)],
+                "collections": ["COLL123"],
+                "tags": [],
+                "date": "2026-03-10",
+                "DOI": "",
+                "url": "",
+            },
+        }
+        docs = [
+            ({
+                "doc_id": "meta:PARENT1",
+                "parent_key": "PARENT1",
+                "attachment_key": "",
+                "doc_kind": "metadata",
+                "chunk_index": 0,
+                "char_start": 0,
+                "char_end": 30,
+                "token_count": 4,
+                "text": "query match metadata",
+                "text_hash": "hash-1",
+            }, 7.5),
+        ]
+        self._install_search_state(docs, parents=parents)
+
+        result = json.loads(db.search_within_item("parent1", "query", limit=3))
+
+        self.assertEqual(
+            result["item"]["creators"],
+            [
+                "Author 1",
+                "Author 2",
+                "Author 3",
+                "Author 4",
+                "Author 5",
+                "... and 3 more",
+            ],
+        )
 
     def test_search_within_item_returns_error_for_unknown_item(self):
         self._install_search_state([


### PR DESCRIPTION
## Summary
- truncate long creator lists to the first 5 names in list and search responses
- preserve the full creator list in `get_item`
- add regression coverage for recent items, collection items, search results, and within-item search

## Testing
- `make test`

Closes #18
