### PR TITLE
Fix #27: batch attachment count lookups in search_library

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -286,6 +286,39 @@ def _get_item_attachment_count(item_key: str) -> int:
     return int(row["count"]) if row else 0
 
 
+def _get_item_attachment_counts(item_keys: list[str]) -> dict[str, int]:
+    """Return attachment counts for many parent items in one query."""
+    normalized_keys: list[str] = []
+    for item_key in item_keys:
+        cleaned = item_key.strip()
+        if cleaned and cleaned not in normalized_keys:
+            normalized_keys.append(cleaned)
+
+    if not normalized_keys:
+        return {}
+
+    placeholders = ",".join("?" for _ in normalized_keys)
+    counts = {key: 0 for key in normalized_keys}
+
+    try:
+        with closing(_open_zotero_db()) as conn:
+            rows = conn.execute(
+                f"""SELECT parent.key, COUNT(*) AS count
+                    FROM itemAttachments ia
+                    JOIN items parent ON parent.itemID = ia.parentItemID
+                    WHERE parent.key IN ({placeholders})
+                    GROUP BY parent.key""",
+                normalized_keys,
+            ).fetchall()
+    except Exception:
+        return counts
+
+    for row in rows:
+        counts[str(row["key"])] = int(row["count"])
+
+    return counts
+
+
 def _item_to_dict(
     item: dict,
     truncate_abstract: int = 0,
@@ -1473,6 +1506,7 @@ def _result_from_parent(
     score: float,
     best_doc: dict[str, Any],
     query_terms: list[str],
+    attachment_count: int,
 ) -> dict[str, Any]:
     result = {
         "key": parent["key"],
@@ -1485,7 +1519,7 @@ def _result_from_parent(
         "tags": list(parent["tags"]),
         "collections": list(parent["collections"]),
         "abstract": parent["abstract"][:500] + "..." if len(parent["abstract"]) > 500 else parent["abstract"],
-        "attachment_count": _get_item_attachment_count(parent["key"]),
+        "attachment_count": attachment_count,
         "score": round(score, 4),
     }
 
@@ -1657,12 +1691,14 @@ def search(
 
         batch_size = min(max_docs, batch_size * 2)
 
+    attachment_counts = _get_item_attachment_counts(list(best_by_parent))
     results_payload = [
         _result_from_parent(
             state.parents[parent_key],
             score=score,
             best_doc=doc,
             query_terms=query_terms,
+            attachment_count=attachment_counts.get(parent_key, 0),
         )
         for parent_key, (score, doc) in best_by_parent.items()
     ]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -231,6 +231,95 @@ class AttachmentPathsTests(DbTestCase):
         self.assertNotIn("attachments", result["results"][0])
         self.assertEqual(result["results"][0]["snippet_attachment_key"], "ATTACH1")
 
+    def test_search_batches_attachment_count_lookups_for_multiple_results(self):
+        with closing(sqlite3.connect(db._ZOTERO_DB)) as conn:
+            conn.execute(
+                "INSERT INTO items(itemID, key, dateAdded) VALUES (?, ?, ?)",
+                (3, "PARENT2", "2026-03-10 10:02:00"),
+            )
+            conn.execute(
+                "INSERT INTO items(itemID, key, dateAdded) VALUES (?, ?, ?)",
+                (4, "ATTACH2", "2026-03-10 10:03:00"),
+            )
+            conn.execute(
+                "INSERT INTO itemDataValues(valueID, value) VALUES (?, ?)",
+                (2, "Attached EPUB"),
+            )
+            conn.execute(
+                "INSERT INTO itemData(itemID, fieldID, valueID) VALUES (?, ?, ?)",
+                (4, 1, 2),
+            )
+            conn.execute(
+                """INSERT INTO itemAttachments(itemID, parentItemID, linkMode, contentType, path)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (4, 3, 1, "application/epub+zip", "storage:book.epub"),
+            )
+            conn.commit()
+
+        parents = {
+            "PARENT1": {
+                "key": "PARENT1",
+                "dateModified": "2026-03-10 10:00:00",
+                "itemType": "preprint",
+                "title": "Example Paper",
+                "abstract": "Example abstract.",
+                "creators": ["Jane Example"],
+                "collections": ["COLL123"],
+                "tags": ["chemistry"],
+                "date": "2026-03-10",
+                "DOI": "10.1000/example",
+                "url": "https://example.org/paper",
+            },
+            "PARENT2": {
+                "key": "PARENT2",
+                "dateModified": "2026-03-11 10:00:00",
+                "itemType": "preprint",
+                "title": "Second Paper",
+                "abstract": "Second abstract.",
+                "creators": ["John Example"],
+                "collections": ["COLL456"],
+                "tags": ["biology"],
+                "date": "2026-03-11",
+                "DOI": "",
+                "url": "",
+            },
+        }
+        docs = [
+            ({
+                "doc_id": "meta:PARENT1",
+                "parent_key": "PARENT1",
+                "attachment_key": "",
+                "doc_kind": "metadata",
+                "chunk_index": 0,
+                "char_start": 0,
+                "char_end": 20,
+                "token_count": 3,
+                "text": "example result one",
+                "text_hash": "hash-1",
+            }, 4.0),
+            ({
+                "doc_id": "meta:PARENT2",
+                "parent_key": "PARENT2",
+                "attachment_key": "",
+                "doc_kind": "metadata",
+                "chunk_index": 0,
+                "char_start": 0,
+                "char_end": 20,
+                "token_count": 3,
+                "text": "example result two",
+                "text_hash": "hash-2",
+            }, 3.5),
+        ]
+        self._install_search_state(docs, parents=parents)
+
+        with patch("zoty.db._open_zotero_db", wraps=db._open_zotero_db) as open_db_mock:
+            result = json.loads(db.search("example", limit=2))
+
+        self.assertEqual(result["total"], 2)
+        self.assertEqual([row["key"] for row in result["results"]], ["PARENT1", "PARENT2"])
+        self.assertEqual([row["attachment_count"] for row in result["results"]], [1, 1])
+        self.assertEqual(open_db_mock.call_count, 1)
+
 
 class CollectionItemTests(DbTestCase):
     def test_list_collection_items_returns_structured_error_for_invalid_key(self):


### PR DESCRIPTION
## Summary
- batch attachment count lookups for `search_library` results in a single SQLite query
- pass the preloaded counts into search result assembly instead of querying per result
- add a regression test covering multiple search results in one call

## Testing
- `make test`

Closes #27
