### PR TITLE
Fix #28: validate arXiv error entries before item creation

### DIFF
--- a/src/zoty/connector.py
+++ b/src/zoty/connector.py
@@ -464,7 +464,10 @@ def _fetch_arxiv_metadata(arxiv_id: str) -> dict:
     if entry is None:
         raise ValueError(f"No arXiv entry found for ID: {arxiv_id}")
 
+    entry_id = (entry.findtext(f"{_ATOM}id") or "").strip()
     title = (entry.findtext(f"{_ATOM}title") or "").strip().replace("\n", " ")
+    if not title or "api/errors" in entry_id or title.lower() == "error":
+        raise ValueError(f"Invalid arXiv ID: {arxiv_id}. No paper found.")
     abstract = (entry.findtext(f"{_ATOM}summary") or "").strip().replace("\n", " ")
     published = (entry.findtext(f"{_ATOM}published") or "")[:10]
 
@@ -771,5 +774,7 @@ def add_paper(arxiv_id: str = "", doi: str = "", collection_key: str = "") -> st
         if "Connection refused" in str(e) or "localhost" in str(e):
             return json.dumps({"error": "Cannot reach Zotero connector at localhost:23119. Is Zotero running?"})
         return json.dumps({"error": f"Failed to fetch metadata from {source}: {e}"})
+    except ValueError as e:
+        return json.dumps({"error": str(e)})
     except Exception as e:
         return json.dumps({"error": f"Failed to add paper: {e}"})

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -106,6 +106,29 @@ class ArxivRateLimiterTests(unittest.TestCase):
         self.assertEqual(result["creators"][0]["lastName"], "Example")
         run_mock.assert_called_once()
 
+    def test_fetch_arxiv_metadata_rejects_error_entries(self):
+        feed = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/api/errors#id_list=not-a-real-id</id>
+    <title>Error</title>
+    <summary>Invalid id_list parameter.</summary>
+  </entry>
+</feed>"""
+
+        with patch.object(connector._ARXIV_METADATA_LIMITER, "run", return_value=feed):
+            with self.assertRaisesRegex(ValueError, r"Invalid arXiv ID: not-a-real-id\. No paper found\."):
+                connector._fetch_arxiv_metadata("not-a-real-id")
+
+    def test_add_paper_returns_validation_error_for_invalid_arxiv_id(self):
+        with patch(
+            "zoty.connector._fetch_arxiv_metadata",
+            side_effect=ValueError("Invalid arXiv ID: not-a-real-id. No paper found."),
+        ):
+            result = json.loads(connector.add_paper(arxiv_id="not-a-real-id"))
+
+        self.assertEqual(result, {"error": "Invalid arXiv ID: not-a-real-id. No paper found."})
+
     @patch("zoty.connector._retrieve_url", autospec=True)
     def test_download_with_rate_limit_uses_pdf_limiter_for_arxiv_urls(self, retrieve_mock):
         with patch.object(


### PR DESCRIPTION
## Summary
- reject arXiv API error-entry payloads before they can be turned into Zotero metadata items
- surface invalid arXiv IDs back through `add_paper` as a direct validation error instead of a generic wrapper
- add regression coverage for both the XML parsing path and the public `add_paper` response

## Testing
- `uv run python -m unittest tests.test_connector -v`

Closes #28
