### PR TITLE
Clarify citation style tool values

### DIFF
--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -107,7 +107,9 @@ def get_bibtex_and_citation_for_items(
     Args:
         item_key: A single Zotero item key, typically returned by search_library
         item_keys: Optional list of Zotero item keys, typically returned by search_library
-        style: Citation style to use for formatted citation and bibliography text
+        style: CSL style ID to use for formatted citation and bibliography text (for example,
+            'apa', 'ieee', or 'chicago-note-bibliography'); see the Zotero Style Repository
+            for the full list
         locale: Citation locale to use for formatted citation and bibliography text
 
     Returns:


### PR DESCRIPTION
## Summary
- Clarified the `style` parameter description for `get_bibtex_and_citation_for_items` with CSL style ID examples and a pointer to the Zotero Style Repository.

## Testing
- make test

Closes #9
