### PR TITLE
docs: enumerate search_library item types

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The bridge runs an HTTP server on `localhost:24119` when Zotero is open. No conf
 
 | Tool | Description |
 |------|-------------|
-| `search_library` | BM25-ranked search over title, abstract, and indexed attachment full text, aggregated back to parent items with optional plain-text snippets, attachment counts, filters for collection or item type, and explicit limit-cap metadata |
+| `search_library` | BM25-ranked search over title, abstract, and indexed attachment full text, aggregated back to parent items with optional plain-text snippets, attachment counts, filters for collection or case-insensitive item type values like `journalArticle`, `preprint`, `conferencePaper`, `book`, `bookSection`, `thesis`, `report`, and `webpage`, plus explicit limit-cap metadata |
 | `search_within_item` | BM25-ranked passage search within one Zotero item, returning top metadata or attachment-chunk matches with snippets, attachment context, and a minimal item summary |
 | `list_collections` | List all collections with keys, names, and item counts |
 | `list_collection_items` | List items in a specific collection |

--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -25,7 +25,9 @@ def search_library(
     Args:
         query: Search keywords (e.g. "transformer attention" not "what papers discuss attention?")
         collection_key: Optional Zotero collection key to filter results
-        item_type: Optional item type filter (e.g. "journalArticle", "preprint", "conferencePaper")
+        item_type: Optional Zotero item type filter, case-insensitive
+            (e.g. "journalArticle", "preprint", "conferencePaper", "book",
+            "bookSection", "thesis", "report", "webpage")
         limit: Maximum results to return (default: 10)
 
     Returns:


### PR DESCRIPTION
## Summary
- Expand the `search_library` item_type description to enumerate common Zotero item types.
- Note that the filter is case-insensitive.

## Testing
- `uv run python -m unittest discover -s tests -v`
- `make test`

Closes #11
