### PR TITLE
fix output: make attachment linkMode human-readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ The bridge runs an HTTP server on `localhost:24119` when Zotero is open. No conf
 | `get_recent_items` | Recently added items, sorted by date |
 | `add_paper` | Add a paper by arXiv ID or DOI with automatic PDF download and collection-scoped duplicate prevention |
 
+Attachment payloads include `linkMode` as a descriptive string (`imported_file`, `imported_url`, `linked_file`, or `linked_url`) instead of Zotero's internal numeric codes.
+
 ## How it works
 
 Read operations still use [pyzotero](https://github.com/urschrei/pyzotero) for collection/item APIs, but search now runs off a persistent sidecar index under `~/.cache/zoty/fulltext-index`. zoty reads Zotero metadata from `zotero.sqlite` in immutable mode, reuses Zotero's extracted attachment text caches (`.zotero-ft-cache`) for PDF/EPUB/HTML full text, chunks that text locally, and rebuilds immutable BM25 snapshots in the background. At startup zoty loads the active snapshot synchronously if one exists, then queues a refresh when Zotero content changed.

--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -39,6 +39,12 @@ _CHUNK_WORDS = 200
 _CHUNK_OVERLAP_WORDS = 40
 _SEARCH_RESULT_LIMIT_CAP = 25
 _LIST_VIEW_MAX_CREATORS = 5
+_LINK_MODE_LABELS = {
+    0: "imported_file",
+    1: "imported_url",
+    2: "linked_file",
+    3: "linked_url",
+}
 
 @dataclass
 class _ParentRecord:
@@ -195,6 +201,13 @@ def _safe_int(value: Any) -> int | None:
         return None
 
 
+def _format_link_mode(value: Any) -> str:
+    mode = _safe_int(value)
+    if mode is None:
+        return "unknown"
+    return _LINK_MODE_LABELS.get(mode, f"unknown({mode})")
+
+
 def _safe_file_stats(path_str: str) -> tuple[int | None, int | None]:
     if not path_str:
         return None, None
@@ -285,7 +298,7 @@ def _get_item_attachments(item_key: str) -> list[dict]:
             "key": attachment_key,
             "title": title,
             "contentType": content_type or "",
-            "linkMode": link_mode,
+            "linkMode": _format_link_mode(link_mode),
             "filepath": filepath,
         })
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -183,11 +183,19 @@ class AttachmentPathsTests(DbTestCase):
                     "key": "ATTACH1",
                     "title": "Attached PDF",
                     "contentType": "application/pdf",
-                    "linkMode": 0,
+                    "linkMode": "imported_file",
                     "filepath": str(db._ZOTERO_STORAGE / "ATTACH1" / "paper.pdf"),
                 }
             ],
         )
+
+    def test_format_link_mode_maps_known_and_unknown_values(self):
+        self.assertEqual(db._format_link_mode(0), "imported_file")
+        self.assertEqual(db._format_link_mode(1), "imported_url")
+        self.assertEqual(db._format_link_mode(2), "linked_file")
+        self.assertEqual(db._format_link_mode(3), "linked_url")
+        self.assertEqual(db._format_link_mode(99), "unknown(99)")
+        self.assertEqual(db._format_link_mode(None), "unknown")
 
     def test_get_item_includes_attachment_filepaths(self):
         zot = Mock()
@@ -485,7 +493,7 @@ class CollectionItemTests(DbTestCase):
                     "key": "ATTACH1",
                     "title": "Collection PDF",
                     "contentType": "application/pdf",
-                    "linkMode": 0,
+                    "linkMode": "imported_file",
                     "filepath": str(db._ZOTERO_STORAGE / "ATTACH1" / "collection.pdf"),
                 }
             ],
@@ -759,7 +767,7 @@ class RecentItemsTests(DbTestCase):
                     "key": "ATTACH1",
                     "title": "Recent PDF",
                     "contentType": "application/pdf",
-                    "linkMode": 0,
+                    "linkMode": "imported_file",
                     "filepath": str(db._ZOTERO_STORAGE / "ATTACH1" / "recent.pdf"),
                 }
             ],


### PR DESCRIPTION
## Summary
- map attachment `linkMode` from Zotero integer codes to descriptive strings in API output (`imported_file`, `imported_url`, `linked_file`, `linked_url`)
- add explicit fallback output for unexpected or missing link mode values
- update DB tests and README to reflect the new output format

## Testing
- `uv run python -m unittest tests.test_db -v`
- `uv run python -m unittest discover -s tests -v`
- `make test`

Closes #13
