### PR TITLE
workflow: clarify when get_item is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The bridge runs an HTTP server on `localhost:24119` when Zotero is open. No conf
 | `search_within_item` | BM25-ranked passage search within one Zotero item, returning top metadata or attachment-chunk matches with snippets, attachment context, and a minimal item summary |
 | `list_collections` | List all collections with keys, names, and item counts |
 | `list_collection_items` | List items in a specific collection |
-| `get_item` | Full metadata for a single item by key, including attachment filepaths |
+| `get_item` | Full metadata for a single item by key, including the full untruncated abstract and attachment filepaths; search results already include most fields, so use this only when the full abstract is needed |
 | `get_bibtex_and_citation_for_items` | BibTeX plus formatted citation and bibliography text for one item key or a list of item keys, typically from `search_library` |
 | `get_recent_items` | Recently added items, sorted by date |
 | `add_paper` | Add a paper by arXiv ID or DOI with automatic PDF download and collection-scoped duplicate prevention |

--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -89,8 +89,10 @@ def get_item(item_key: str) -> str:
         item_key: The Zotero item key
 
     Returns:
-        JSON with complete item metadata including title, creators, abstract,
-        date, DOI, URL, tags, collections, and attachment filepaths.
+        JSON with complete item metadata including the full untruncated abstract,
+        title, creators, date, DOI, URL, tags, collections, and attachment
+        filepaths. Search results already include most fields, so use this only
+        when the full abstract is needed.
     """
     return db.get_item(item_key)
 


### PR DESCRIPTION
## Summary
- Clarify that `get_item` returns the full untruncated abstract and that `search_library` already includes most other fields.
- Update the README tool table with the same guidance.

## Testing
- `uv run --with pytest python -m pytest tests/test_server.py`

Closes #29
