### PR TITLE
fix: remove mktemp TOCTOU race in _download_pdf

### DIFF
--- a/src/zoty/connector.py
+++ b/src/zoty/connector.py
@@ -428,7 +428,8 @@ def _download_pdf(pdf_url: str, filename: str) -> tuple[str, Path, int] | None:
     """Download PDF to Zotero storage. Returns (att_key, dest_path, size) or None."""
     tmp = ""
     try:
-        tmp = tempfile.mktemp(suffix=".pdf")
+        fd, tmp = tempfile.mkstemp(suffix=".pdf")
+        os.close(fd)
         _download_with_rate_limit(pdf_url, tmp)
         file_size = os.path.getsize(tmp)
         if file_size < 1000:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -162,6 +162,32 @@ class ArxivRateLimiterTests(unittest.TestCase):
         )
 
 
+class DownloadPdfSecurityTests(unittest.TestCase):
+    def test_download_pdf_uses_mkstemp_and_closes_fd(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            temp_pdf = tmpdir_path / "download.pdf"
+
+            def fake_download(_url, path):
+                Path(path).write_bytes(b"x" * 2000)
+
+            with (
+                patch("zoty.connector.tempfile.mkstemp", return_value=(17, str(temp_pdf))) as mkstemp_mock,
+                patch("zoty.connector.tempfile.mktemp", side_effect=AssertionError("mktemp should not be used")),
+                patch("zoty.connector.os.close") as close_mock,
+                patch("zoty.connector._download_with_rate_limit", side_effect=fake_download),
+                patch("zoty.connector._zotero_key", return_value="ATTACH1"),
+                patch("zoty.connector._ZOTERO_STORAGE", tmpdir_path),
+            ):
+                result = connector._download_pdf("https://example.org/paper.pdf", "paper.pdf")
+                self.assertEqual(result[0], "ATTACH1")
+                self.assertEqual(result[2], 2000)
+                self.assertEqual(result[1], tmpdir_path / "ATTACH1" / "paper.pdf")
+                self.assertTrue(result[1].exists())
+                mkstemp_mock.assert_called_once_with(suffix=".pdf")
+                close_mock.assert_called_once_with(17)
+
+
 class CollectionAssignmentRetryTests(unittest.TestCase):
     @patch("zoty.connector.time.sleep", autospec=True)
     def test_retries_bridge_http_400(self, sleep_mock):


### PR DESCRIPTION
## Summary
- replace insecure `tempfile.mktemp` usage in `_download_pdf` with `tempfile.mkstemp` to avoid TOCTOU races
- close the returned file descriptor before downloading into the temporary path
- add a regression test that asserts `_download_pdf` uses `mkstemp` and does not call `mktemp`

## Testing
- make test

Closes #25
