### PR TITLE
Fix serialized arXiv limiter lock contention

### DIFF
--- a/src/zoty/connector.py
+++ b/src/zoty/connector.py
@@ -57,18 +57,31 @@ class _SerializedRateLimiter:
         self._clock = clock
         self._sleep = sleep
         self._lock = threading.Lock()
+        self._condition = threading.Condition(self._lock)
+        self._in_flight = False
         self._next_allowed_at = 0.0
 
     def run(self, func, *args, **kwargs):
-        with self._lock:
-            wait = self._next_allowed_at - self._clock()
-            if wait > 0:
-                self._sleep(wait)
+        while True:
+            with self._condition:
+                if self._in_flight:
+                    self._condition.wait()
+                    continue
 
-            try:
-                return func(*args, **kwargs)
-            finally:
+                wait = self._next_allowed_at - self._clock()
+                if wait <= 0:
+                    self._in_flight = True
+                    break
+
+            self._sleep(wait)
+
+        try:
+            return func(*args, **kwargs)
+        finally:
+            with self._condition:
                 self._next_allowed_at = self._clock() + self._min_interval
+                self._in_flight = False
+                self._condition.notify_all()
 
 
 class _SlidingWindowRateLimiter:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2,6 +2,7 @@ from contextlib import closing
 import json
 import sqlite3
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -69,6 +70,42 @@ class ArxivRateLimiterTests(unittest.TestCase):
 
         self.assertEqual(starts, [("fail", 0.0), ("success", 3.2)])
         self.assertEqual(clock.sleeps, [3.0])
+
+    def test_serialized_rate_limiter_releases_lock_during_call(self):
+        limiter = connector._SerializedRateLimiter(min_interval=0.0)
+        started = threading.Event()
+        release = threading.Event()
+        done = threading.Event()
+        errors = []
+
+        def blocking_call():
+            started.set()
+            release.wait(timeout=1.0)
+            return "ok"
+
+        def worker():
+            try:
+                limiter.run(blocking_call)
+            except Exception as exc:  # pragma: no cover - defensive
+                errors.append(exc)
+            finally:
+                done.set()
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        self.assertTrue(started.wait(timeout=1.0))
+
+        # If run() holds _lock during func(), this acquire times out.
+        acquired = limiter._lock.acquire(timeout=0.1)
+        if acquired:
+            limiter._lock.release()
+
+        release.set()
+        self.assertTrue(done.wait(timeout=1.0))
+        thread.join(timeout=1.0)
+
+        self.assertTrue(acquired)
+        self.assertEqual(errors, [])
 
     def test_sliding_window_rate_limiter_allows_burst_then_waits(self):
         clock = FakeClock()


### PR DESCRIPTION
## Summary
- Refactored `_SerializedRateLimiter.run` to separate scheduling from execution so the internal lock is not held while `func(...)` runs.
- Added condition-based in-flight coordination to keep serialized ordering while preserving the post-call quiet interval.
- Added a regression test that verifies the limiter lock is releasable while a blocking call is in progress.

## Testing
- `uv run python -m unittest tests.test_connector.ArxivRateLimiterTests -v`
- `make test`

Closes #26
