### PR TITLE
Clarify add_paper input requirements

### DIFF
--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -158,14 +158,20 @@ def get_recent_items(limit: int = 10) -> str:
 def add_paper(arxiv_id: str = "", doi: str = "", collection_key: str = "") -> str:
     """Add a paper to Zotero by arXiv ID or DOI.
 
+    Provide at least one of `arxiv_id` or `doi`. If both are provided,
+    `arxiv_id` takes precedence.
+
     Fetches metadata from arXiv or CrossRef, creates the item via the Zotero
     connector, downloads the PDF, and optionally assigns to a collection.
     PDF attachment and collection assignment use the Zotero JS API via the
     zoty-bridge plugin. Zotero desktop must be running.
 
     Args:
-        arxiv_id: arXiv paper ID (e.g. "2301.07041" or "arxiv:2301.07041")
-        doi: DOI (e.g. "10.1038/s41586-021-03819-2")
+        arxiv_id: arXiv paper ID (e.g. "2301.07041" or "arxiv:2301.07041").
+            Required unless `doi` is provided. Takes precedence when both are
+            provided.
+        doi: DOI (e.g. "10.1038/s41586-021-03819-2"). Required unless
+            `arxiv_id` is provided. Ignored when `arxiv_id` is provided.
         collection_key: Optional Zotero collection key to add the paper to (from list_collections)
 
     Returns:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from unittest.mock import patch
 
@@ -124,3 +125,17 @@ class ServerToolTests(unittest.TestCase):
             style="apa",
             locale="en-GB",
         )
+
+    def test_add_paper_tool_description_mentions_required_inputs_and_precedence(self):
+        async def get_tool_description():
+            tools = await server.mcp_server.list_tools()
+            for tool in tools:
+                if tool.name == "add_paper":
+                    return tool.description
+            self.fail("add_paper tool was not registered")
+
+        description = asyncio.run(get_tool_description())
+
+        self.assertIn("Provide at least one of `arxiv_id` or `doi`.", description)
+        self.assertIn("If both are provided,", description)
+        self.assertIn("`arxiv_id` takes precedence.", description)


### PR DESCRIPTION
## Summary\n- Clarify that add_paper requires at least one of arxiv_id or doi.\n- Note that arxiv_id takes precedence when both are provided.\n- Add a server test that inspects the registered tool description.\n\n## Testing\n- make test