### PR TITLE
fix(output): standardize error payload skeletons

### DIFF
--- a/src/zoty/connector.py
+++ b/src/zoty/connector.py
@@ -257,6 +257,24 @@ def _parse_rdp_result(bridge_response: dict) -> dict:
     return bridge_response
 
 
+def _add_paper_error_payload(error: str, *, collection_key: str = "") -> dict[str, object]:
+    """Return the add_paper failure shape with empty success fields."""
+    return {
+        "status": "error",
+        "title": "",
+        "creators": [],
+        "date": "",
+        "itemType": "",
+        "DOI": "",
+        "url": "",
+        "abstract": "",
+        "pdf_attached": False,
+        "collection_added": False,
+        "collection_key": collection_key,
+        "error": error,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -649,7 +667,7 @@ def add_paper(arxiv_id: str = "", doi: str = "", collection_key: str = "") -> st
     (the metadata item and downloaded PDF are still preserved).
     """
     if not arxiv_id and not doi:
-        return json.dumps({"error": "Provide at least one of arxiv_id or doi"})
+        return json.dumps(_add_paper_error_payload("Provide at least one of arxiv_id or doi", collection_key=collection_key))
 
     try:
         existing_key, existing_title = _find_existing_item_in_collection(
@@ -786,9 +804,19 @@ def add_paper(arxiv_id: str = "", doi: str = "", collection_key: str = "") -> st
     except urllib.error.URLError as e:
         source = "arXiv" if arxiv_id else "CrossRef"
         if "Connection refused" in str(e) or "localhost" in str(e):
-            return json.dumps({"error": "Cannot reach Zotero connector at localhost:23119. Is Zotero running?"})
-        return json.dumps({"error": f"Failed to fetch metadata from {source}: {e}"})
+            return json.dumps(
+                _add_paper_error_payload(
+                    "Cannot reach Zotero connector at localhost:23119. Is Zotero running?",
+                    collection_key=collection_key,
+                )
+            )
+        return json.dumps(
+            _add_paper_error_payload(
+                f"Failed to fetch metadata from {source}: {e}",
+                collection_key=collection_key,
+            )
+        )
     except ValueError as e:
-        return json.dumps({"error": str(e)})
+        return json.dumps(_add_paper_error_payload(str(e), collection_key=collection_key))
     except Exception as e:
-        return json.dumps({"error": f"Failed to add paper: {e}"})
+        return json.dumps(_add_paper_error_payload(f"Failed to add paper: {e}", collection_key=collection_key))

--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -398,6 +398,23 @@ def _item_to_dict(
     return result
 
 
+def _empty_item_payload(item_key: str = "") -> dict[str, Any]:
+    """Return the get_item shape with empty values for error responses."""
+    return {
+        "key": item_key,
+        "itemType": "",
+        "title": "",
+        "creators": [],
+        "date": "",
+        "DOI": "",
+        "url": "",
+        "tags": [],
+        "collections": [],
+        "abstract": "",
+        "attachments": [],
+    }
+
+
 def _normalize_item_keys(item_key: str = "", item_keys: list[str] | None = None) -> list[str]:
     """Normalize a single key and/or key list into a clean ordered list."""
     normalized: list[str] = []
@@ -1881,7 +1898,7 @@ def list_collections() -> str:
         zot = _get_zot()
         collections = zot.collections()
     except Exception as exc:
-        return json.dumps({"error": f"Failed to fetch collections: {exc}"})
+        return json.dumps({"collections": [], "total": 0, "error": f"Failed to fetch collections: {exc}"})
 
     result = []
     for collection in collections:
@@ -1968,13 +1985,17 @@ def get_item(item_key: str) -> str:
     """Full metadata for a single item."""
     normalized_item_key = item_key.strip()
     if not normalized_item_key:
-        return json.dumps({"error": "Provide item_key"})
+        payload = _empty_item_payload()
+        payload["error"] = "Provide item_key"
+        return json.dumps(payload)
 
     try:
         zot = _get_zot()
         item = zot.item(normalized_item_key)
     except Exception as exc:
-        return json.dumps({"error": f"Failed to fetch item {normalized_item_key}: {exc}"})
+        payload = _empty_item_payload(normalized_item_key)
+        payload["error"] = f"Failed to fetch item {normalized_item_key}: {exc}"
+        return json.dumps(payload)
 
     return json.dumps(_item_to_dict(item, truncate_abstract=0, include_attachments=True))
 
@@ -2040,7 +2061,7 @@ def get_recent_items(limit: int = 10) -> str:
         )
         items = [item for item in items if item.get("data", {}).get("itemType") not in _SKIP_TYPES][:limit]
     except Exception as exc:
-        return json.dumps({"error": f"Failed to fetch recent items: {exc}"})
+        return json.dumps({"items": [], "total": 0, "error": f"Failed to fetch recent items: {exc}"})
 
     result = [
         _item_to_dict(

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -164,7 +164,18 @@ class ArxivRateLimiterTests(unittest.TestCase):
         ):
             result = json.loads(connector.add_paper(arxiv_id="not-a-real-id"))
 
-        self.assertEqual(result, {"error": "Invalid arXiv ID: not-a-real-id. No paper found."})
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["title"], "")
+        self.assertEqual(result["creators"], [])
+        self.assertEqual(result["date"], "")
+        self.assertEqual(result["itemType"], "")
+        self.assertEqual(result["DOI"], "")
+        self.assertEqual(result["url"], "")
+        self.assertEqual(result["abstract"], "")
+        self.assertFalse(result["pdf_attached"])
+        self.assertFalse(result["collection_added"])
+        self.assertEqual(result["collection_key"], "")
+        self.assertEqual(result["error"], "Invalid arXiv ID: not-a-real-id. No paper found.")
 
     @patch("zoty.connector._retrieve_url", autospec=True)
     def test_download_with_rate_limit_uses_pdf_limiter_for_arxiv_urls(self, retrieve_mock):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -226,15 +226,50 @@ class AttachmentPathsTests(DbTestCase):
         with patch("zoty.db._get_zot") as get_zot_mock:
             result = json.loads(db.get_item(""))
 
-        self.assertEqual(result, {"error": "Provide item_key"})
+        self.assertEqual(result["error"], "Provide item_key")
+        self.assertEqual(result["key"], "")
+        self.assertEqual(result["itemType"], "")
+        self.assertEqual(result["creators"], [])
+        self.assertEqual(result["tags"], [])
+        self.assertEqual(result["collections"], [])
+        self.assertEqual(result["attachments"], [])
         get_zot_mock.assert_not_called()
 
     def test_get_item_rejects_whitespace_only_item_key(self):
         with patch("zoty.db._get_zot") as get_zot_mock:
             result = json.loads(db.get_item("   "))
 
-        self.assertEqual(result, {"error": "Provide item_key"})
+        self.assertEqual(result["error"], "Provide item_key")
+        self.assertEqual(result["key"], "")
+        self.assertEqual(result["itemType"], "")
+        self.assertEqual(result["creators"], [])
+        self.assertEqual(result["tags"], [])
+        self.assertEqual(result["collections"], [])
+        self.assertEqual(result["attachments"], [])
         get_zot_mock.assert_not_called()
+
+    def test_get_item_returns_structured_error_skeleton_for_fetch_failure(self):
+        zot = Mock()
+        zot.item.side_effect = RuntimeError("boom")
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.get_item("PARENT1"))
+
+        self.assertEqual(result["key"], "PARENT1")
+        self.assertEqual(result["itemType"], "")
+        self.assertEqual(result["creators"], [])
+        self.assertEqual(result["tags"], [])
+        self.assertEqual(result["collections"], [])
+        self.assertEqual(result["attachments"], [])
+        self.assertIn("Failed to fetch item PARENT1: boom", result["error"])
+
+    def test_list_collections_returns_structured_error_skeleton_for_fetch_failure(self):
+        with patch("zoty.db._get_zot", side_effect=RuntimeError("boom")):
+            result = json.loads(db.list_collections())
+
+        self.assertEqual(result["collections"], [])
+        self.assertEqual(result["total"], 0)
+        self.assertIn("Failed to fetch collections: boom", result["error"])
 
     def test_search_includes_attachment_count(self):
         attachment_doc = {
@@ -561,6 +596,14 @@ class RecentItemsTests(DbTestCase):
                 "... and 3 more",
             ],
         )
+
+    def test_get_recent_items_returns_structured_error_skeleton_for_fetch_failure(self):
+        with patch("zoty.db._get_zot", side_effect=RuntimeError("boom")):
+            result = json.loads(db.get_recent_items(limit=1))
+
+        self.assertEqual(result["items"], [])
+        self.assertEqual(result["total"], 0)
+        self.assertIn("Failed to fetch recent items: boom", result["error"])
 
 
 class ParentRecordDateNormalizationTests(DbTestCase):


### PR DESCRIPTION
## Summary\nStandardize error responses for item, collection, recent-item, and add_paper tools so failures preserve each tool's expected payload shape instead of returning bare `{"error": ...}` objects.\n\n## Tests\n- uv run python -m unittest tests.test_db tests.test_connector\n- uv run python -m unittest discover -s tests