### PR TITLE
fix(db): use read-only manifest connections

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -482,7 +482,7 @@ def _connect_manifest(*, writable: bool = False) -> sqlite3.Connection:
     if writable:
         conn = sqlite3.connect(path)
     else:
-        conn = sqlite3.connect(f"file:{path}?immutable=1", uri=True)
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     return conn
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1417,6 +1417,19 @@ class SnapshotLifecycleTests(DbTestCase):
             source_signature=signature,
         )
 
+    def test_connect_manifest_uses_read_only_uri_for_read_connections(self):
+        mock_conn = Mock()
+
+        with patch("zoty.db.sqlite3.connect", return_value=mock_conn) as connect_mock:
+            conn = db._connect_manifest()
+
+        self.assertIs(conn, mock_conn)
+        connect_mock.assert_called_once_with(
+            f"file:{db._manifest_db_path()}?mode=ro",
+            uri=True,
+        )
+        self.assertEqual(mock_conn.row_factory, sqlite3.Row)
+
     def test_prepare_search_index_loads_existing_snapshot_and_skips_refresh(self):
         parent = self._make_parent()
         doc = db._build_metadata_doc(parent)


### PR DESCRIPTION
Fixes #82

Replace the manifest read connection URI from  to  so reads respect SQLite locking while preserving writable behavior.

Validation:
- PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -v