### PR TITLE
Fix citation export performance and payload bloat

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -39,6 +40,7 @@ _CHUNK_WORDS = 200
 _CHUNK_OVERLAP_WORDS = 40
 _SEARCH_RESULT_LIMIT_CAP = 25
 _LIST_VIEW_MAX_CREATORS = 5
+_CITATION_EXPORT_MAX_WORKERS = 4
 _EMPTY_QUERY_WARNING = "Query produced no searchable terms after stop-word removal. Try more specific keywords."
 _LINK_MODE_LABELS = {
     0: "imported_file",
@@ -434,6 +436,75 @@ def _xhtml_to_text(fragment: str) -> str:
     """Collapse Zotero's XHTML bibliography/citation output into plain text."""
     text = re.sub(r"<[^>]+>", " ", fragment)
     return " ".join(html.unescape(text).split())
+
+
+def _strip_bibtex_field(bibtex: str, field_name: str) -> str:
+    """Remove a top-level BibTeX field from each entry while preserving the rest."""
+    if not bibtex:
+        return ""
+
+    field_pattern = re.compile(rf"^[ \t]*{re.escape(field_name)}[ \t]*=", re.IGNORECASE)
+    output: list[str] = []
+    index = 0
+    length = len(bibtex)
+
+    while index < length:
+        if index == 0 or bibtex[index - 1] == "\n":
+            line_end = bibtex.find("\n", index)
+            if line_end == -1:
+                line_end = length
+
+            field_match = field_pattern.match(bibtex[index:line_end])
+            if field_match:
+                value_index = index + field_match.end()
+                while value_index < length and bibtex[value_index] in " \t\r\n":
+                    value_index += 1
+
+                if value_index < length and bibtex[value_index] == "{":
+                    depth = 0
+                    while value_index < length:
+                        char = bibtex[value_index]
+                        if char == "{" and (value_index == 0 or bibtex[value_index - 1] != "\\"):
+                            depth += 1
+                        elif char == "}" and (value_index == 0 or bibtex[value_index - 1] != "\\"):
+                            depth -= 1
+                            if depth == 0:
+                                value_index += 1
+                                break
+                        value_index += 1
+                elif value_index < length and bibtex[value_index] == "\"":
+                    value_index += 1
+                    while value_index < length:
+                        char = bibtex[value_index]
+                        if char == "\"" and bibtex[value_index - 1] != "\\":
+                            value_index += 1
+                            break
+                        value_index += 1
+                else:
+                    while value_index < length and bibtex[value_index] not in ",\n":
+                        value_index += 1
+
+                while value_index < length and bibtex[value_index] in " \t":
+                    value_index += 1
+                if value_index < length and bibtex[value_index] == ",":
+                    value_index += 1
+                while value_index < length and bibtex[value_index] in " \t":
+                    value_index += 1
+                if value_index < length and bibtex[value_index] == "\n":
+                    value_index += 1
+
+                index = value_index
+                continue
+
+        output.append(bibtex[index])
+        index += 1
+
+    return "".join(output)
+
+
+def _compact_bibtex_export(bibtex: str) -> str:
+    """Drop fields that duplicate data already provided by other tools."""
+    return _strip_bibtex_field(bibtex, "abstract").strip()
 
 
 def _fetch_item_exports(
@@ -2018,21 +2089,40 @@ def get_bibtex_and_citation_for_items(
     results: list[dict[str, str]] = []
     errors: list[dict[str, str]] = []
 
-    for key in requested_keys:
+    def _append_success(key: str, exports: dict[str, str]) -> None:
+        results.append({
+            "key": key,
+            "citation": _xhtml_to_text(exports["citation"]),
+            "bibliography": _xhtml_to_text(exports["bibliography"]),
+            "bibtex": _compact_bibtex_export(exports["bibtex"]),
+        })
+
+    if len(requested_keys) == 1:
+        key = requested_keys[0]
         try:
             exports = _fetch_item_exports(key, style=style, locale=locale)
-
-            results.append({
-                "key": key,
-                "citation": _xhtml_to_text(exports["citation"]),
-                "bibliography": _xhtml_to_text(exports["bibliography"]),
-                "bibtex": exports["bibtex"].strip(),
-            })
+            _append_success(key, exports)
         except Exception as exc:
             errors.append({
                 "key": key,
                 "error": f"Failed to fetch citation entry: {exc}",
             })
+    else:
+        max_workers = min(_CITATION_EXPORT_MAX_WORKERS, len(requested_keys))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [
+                executor.submit(_fetch_item_exports, key, style=style, locale=locale)
+                for key in requested_keys
+            ]
+            for key, future in zip(requested_keys, futures):
+                try:
+                    exports = future.result()
+                    _append_success(key, exports)
+                except Exception as exc:
+                    errors.append({
+                        "key": key,
+                        "error": f"Failed to fetch citation entry: {exc}",
+                    })
 
     payload: dict[str, Any] = {
         "items": results,

--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -114,7 +114,7 @@ def get_bibtex_and_citation_for_items(
     style: str = "chicago-note-bibliography",
     locale: str = "en-US",
 ) -> str:
-    """Get BibTeX, citation text, and bibliography text for one or more Zotero items.
+    """Get BibTeX, citation text, and bibliography text for one or more Zotero items. Provide at least one of `item_key` or `item_keys`.
 
     Args:
         item_key: A single Zotero item key for one item. Use the `key` field from

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1648,7 +1648,15 @@ class CitationEntryTests(DbTestCase):
             return {
                 "citation": [f"<span>{item_key} &amp; cite</span>"],
                 "bib": [f"<div>{item_key} <i>reference</i></div>"],
-                "bibtex": [f"@article{{{item_key},\n  title={{Example}}\n}}"],
+                "bibtex": [
+                    (
+                        f"@article{{{item_key},\n"
+                        "  title={Example},\n"
+                        "  abstract={Detailed summary with {nested} braces},\n"
+                        "  year={2026}\n"
+                        "}"
+                    )
+                ],
             }
 
         zot.item.side_effect = item_side_effect
@@ -1673,7 +1681,7 @@ class CitationEntryTests(DbTestCase):
                     "key": "ITEM123",
                     "citation": "ITEM123 & cite",
                     "bibliography": "ITEM123 reference",
-                    "bibtex": "@article{ITEM123,\n  title={Example}\n}",
+                    "bibtex": "@article{ITEM123,\n  title={Example},\n  year={2026}\n}",
                 }
             ],
         )
@@ -1750,7 +1758,7 @@ class CitationEntryTests(DbTestCase):
 
         self.assertEqual(result["total"], 2)
         self.assertEqual(zot.item.call_count, 2)
-        self.assertEqual([args[0] for args, _kwargs in zot.item.call_args_list], ["GOOD1", "GOOD2"])
+        self.assertCountEqual([args[0] for args, _kwargs in zot.item.call_args_list], ["GOOD1", "GOOD2"])
 
         for _args, kwargs in zot.item.call_args_list:
             self.assertEqual(kwargs["format"], "json")
@@ -1758,6 +1766,33 @@ class CitationEntryTests(DbTestCase):
             self.assertEqual(kwargs["style"], "apa")
             self.assertEqual(kwargs["locale"], "en-GB")
             self.assertNotIn("content", kwargs)
+
+    def test_get_bibtex_and_citation_for_items_fetches_multiple_exports_concurrently(self):
+        barrier = threading.Barrier(2)
+
+        def fetch_side_effect(item_key, *, style, locale):
+            self.assertEqual(style, "apa")
+            self.assertEqual(locale, "en-GB")
+            barrier.wait(timeout=1)
+            return {
+                "citation": f"<span>{item_key} cite</span>",
+                "bibliography": f"<div>{item_key} ref</div>",
+                "bibtex": f"@article{{{item_key},\n  abstract={{A long abstract}}\n}}",
+            }
+
+        with patch("zoty.db._fetch_item_exports", side_effect=fetch_side_effect):
+            result = json.loads(
+                db.get_bibtex_and_citation_for_items(
+                    item_keys=["good1", "good2"],
+                    style="apa",
+                    locale="en-GB",
+                )
+            )
+
+        self.assertEqual(result["total"], 2)
+        self.assertNotIn("errors", result)
+        for item in result["items"]:
+            self.assertNotIn("abstract", item["bibtex"].lower())
 
     def test_get_bibtex_and_citation_for_items_requires_at_least_one_key(self):
         result = json.loads(db.get_bibtex_and_citation_for_items())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -126,6 +126,18 @@ class ServerToolTests(unittest.TestCase):
             locale="en-GB",
         )
 
+    def test_get_bibtex_tool_description_mentions_required_key_inputs(self):
+        async def get_tool_description():
+            tools = await server.mcp_server.list_tools()
+            for tool in tools:
+                if tool.name == "get_bibtex_and_citation_for_items":
+                    return tool.description
+            self.fail("get_bibtex_and_citation_for_items tool was not registered")
+
+        description = asyncio.run(get_tool_description())
+
+        self.assertIn("Provide at least one of `item_key` or `item_keys`.", description)
+
     def test_add_paper_tool_description_mentions_required_inputs_and_precedence(self):
         async def get_tool_description():
             tools = await server.mcp_server.list_tools()


### PR DESCRIPTION
## Summary
- parallelize citation export fetches with a bounded thread pool to avoid sequential N+1 latency
- remove abstract from returned BibTeX by default to reduce payload bloat
- strengthen get_bibtex_and_citation_for_items tool description so schema consumers see key requirements
- extend tests for concurrent fetching, BibTeX compaction, and tool description text

## Testing
- PYTHONPATH=src ./.venv/bin/python -m unittest tests.test_db.CitationEntryTests -v
- PYTHONPATH=src ./.venv/bin/python -m unittest tests.test_server.ServerToolTests -v
- make test

Fixes #60
Fixes #64
Fixes #71