### PR TITLE
feat: cap list/recent responses and improve docs

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -38,6 +38,7 @@ _CACHE_CONTENT_TYPES = {
 _CHUNK_WORDS = 200
 _CHUNK_OVERLAP_WORDS = 40
 _SEARCH_RESULT_LIMIT_CAP = 25
+_LIST_RESULT_LIMIT_CAP = 100
 _LIST_VIEW_MAX_CREATORS = 5
 _EMPTY_QUERY_WARNING = "Query produced no searchable terms after stop-word removal. Try more specific keywords."
 _LINK_MODE_LABELS = {
@@ -1626,6 +1627,20 @@ def _search_response(
     return json.dumps(response)
 
 
+def _apply_limit_cap(limit: int, cap: int) -> tuple[int, int]:
+    requested_limit = max(1, limit)
+    return requested_limit, min(requested_limit, cap)
+
+
+def _limit_response_metadata(requested_limit: int, applied_limit: int, cap: int) -> dict[str, Any]:
+    return {
+        "requested_limit": requested_limit,
+        "applied_limit": applied_limit,
+        "limit_cap": cap,
+        "limit_capped": requested_limit > applied_limit,
+    }
+
+
 def _item_summary_from_parent(parent: dict[str, Any]) -> dict[str, Any]:
     return {
         "key": parent["key"],
@@ -1916,7 +1931,7 @@ def list_collections() -> str:
 
 def list_collection_items(collection_key: str, limit: int = 50) -> str:
     """Return items in a specific collection."""
-    limit = max(1, limit)
+    requested_limit, applied_limit = _apply_limit_cap(limit, _LIST_RESULT_LIMIT_CAP)
     normalized_collection_key = collection_key.strip().upper()
     if not normalized_collection_key:
         return json.dumps({
@@ -1924,6 +1939,7 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
             "collection_found": False,
             "items": [],
             "total": 0,
+            **_limit_response_metadata(requested_limit, applied_limit, _LIST_RESULT_LIMIT_CAP),
             "error": "Provide collection_key",
         })
 
@@ -1940,15 +1956,17 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
                 "collection_found": False,
                 "items": [],
                 "total": 0,
+                **_limit_response_metadata(requested_limit, applied_limit, _LIST_RESULT_LIMIT_CAP),
                 "error": f"Collection {normalized_collection_key} was not found",
             })
-        items = zot.collection_items(normalized_collection_key, limit=limit)
+        items = zot.collection_items(normalized_collection_key, limit=applied_limit)
     except Exception as exc:
         return json.dumps({
             "collection_key": normalized_collection_key,
             "collection_found": False,
             "items": [],
             "total": 0,
+            **_limit_response_metadata(requested_limit, applied_limit, _LIST_RESULT_LIMIT_CAP),
             "error": f"Failed to fetch collection items: {exc}",
         })
 
@@ -1978,6 +1996,7 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
         "collection_found": True,
         "items": result,
         "total": len(result),
+        **_limit_response_metadata(requested_limit, applied_limit, _LIST_RESULT_LIMIT_CAP),
     })
 
 
@@ -2051,17 +2070,22 @@ def get_bibtex_and_citation_for_items(
 
 def get_recent_items(limit: int = 10) -> str:
     """Recently added items, sorted by dateAdded descending."""
-    limit = max(1, limit)
+    requested_limit, applied_limit = _apply_limit_cap(limit, _LIST_RESULT_LIMIT_CAP)
     try:
         zot = _get_zot()
         items = zot.items(
-            limit=limit * 3,
+            limit=applied_limit * 3,
             sort="dateAdded",
             direction="desc",
         )
-        items = [item for item in items if item.get("data", {}).get("itemType") not in _SKIP_TYPES][:limit]
+        items = [item for item in items if item.get("data", {}).get("itemType") not in _SKIP_TYPES][:applied_limit]
     except Exception as exc:
-        return json.dumps({"items": [], "total": 0, "error": f"Failed to fetch recent items: {exc}"})
+        return json.dumps({
+            "items": [],
+            "total": 0,
+            **_limit_response_metadata(requested_limit, applied_limit, _LIST_RESULT_LIMIT_CAP),
+            "error": f"Failed to fetch recent items: {exc}",
+        })
 
     result = [
         _item_to_dict(
@@ -2072,4 +2096,8 @@ def get_recent_items(limit: int = 10) -> str:
         )
         for item in items
     ]
-    return json.dumps({"items": result, "total": len(result)})
+    return json.dumps({
+        "items": result,
+        "total": len(result),
+        **_limit_response_metadata(requested_limit, applied_limit, _LIST_RESULT_LIMIT_CAP),
+    })

--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -81,10 +81,13 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
 
     Args:
         collection_key: The Zotero collection key (from list_collections)
-        limit: Maximum items to return (default: 50)
+        limit: Requested items to return before the cap is applied (default: 50)
 
     Returns:
-        JSON with item metadata for each item in the collection.
+        JSON with `collection_key`, `collection_found`, `items`, and limit
+        metadata. Each item includes `key`, `title`, `creators`, `date`,
+        truncated `abstract` (500 chars), `attachments`, and other summary
+        fields.
     """
     return db.list_collection_items(collection_key, limit=limit)
 
@@ -146,10 +149,12 @@ def get_recent_items(limit: int = 10) -> str:
     """Get recently added items from the Zotero library, sorted by date added.
 
     Args:
-        limit: Maximum items to return (default: 10)
+        limit: Requested items to return before the cap is applied (default: 10)
 
     Returns:
-        JSON with item metadata for recently added items.
+        JSON with `items`, `total`, and limit metadata. Each item includes
+        `key`, `title`, `creators`, `date`, truncated `abstract` (500 chars),
+        `attachments`, and other summary fields.
     """
     return db.get_recent_items(limit=limit)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -447,6 +447,10 @@ class CollectionItemTests(DbTestCase):
         self.assertFalse(result["collection_found"])
         self.assertEqual(result["items"], [])
         self.assertEqual(result["total"], 0)
+        self.assertEqual(result["requested_limit"], 50)
+        self.assertEqual(result["applied_limit"], 50)
+        self.assertEqual(result["limit_cap"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
         self.assertIn("not found", result["error"])
         zot.collection_items.assert_not_called()
 
@@ -520,6 +524,10 @@ class CollectionItemTests(DbTestCase):
         self.assertEqual(result["collection_key"], "COLL123")
         self.assertTrue(result["collection_found"])
         self.assertEqual(result["total"], 1)
+        self.assertEqual(result["requested_limit"], 5)
+        self.assertEqual(result["applied_limit"], 5)
+        self.assertEqual(result["limit_cap"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
         self.assertEqual([row["key"] for row in result["items"]], ["ITEM1"])
         self.assertEqual(result["items"][0]["title"], "First Paper")
         self.assertEqual(
@@ -535,6 +543,37 @@ class CollectionItemTests(DbTestCase):
             ],
         )
         zot.collection_items.assert_called_once_with("COLL123", limit=5)
+
+    def test_list_collection_items_caps_requested_limit_and_reports_metadata(self):
+        zot = Mock()
+        zot.collections.return_value = [
+            {"data": {"key": "COLL123", "name": "Valid Collection"}}
+        ]
+        zot.collection_items.return_value = [
+            {
+                "data": {
+                    "key": "ITEM1",
+                    "itemType": "preprint",
+                    "title": "First Paper",
+                    "creators": [{"firstName": "Jane", "lastName": "Example"}],
+                    "date": "2026-03-10",
+                    "DOI": "10.1000/one",
+                    "url": "https://example.org/one",
+                    "tags": [{"tag": "chemistry"}],
+                    "collections": ["COLL123"],
+                    "abstractNote": "First abstract.",
+                }
+            }
+        ]
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.list_collection_items("coll123", limit=999))
+
+        self.assertEqual(result["requested_limit"], 999)
+        self.assertEqual(result["applied_limit"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertEqual(result["limit_cap"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertTrue(result["limit_capped"])
+        zot.collection_items.assert_called_once_with("COLL123", limit=db._LIST_RESULT_LIMIT_CAP)
 
     def test_list_collection_items_truncates_long_creator_lists(self):
         zot = Mock()
@@ -585,6 +624,10 @@ class RecentItemsTests(DbTestCase):
             result = json.loads(db.get_recent_items(limit=1))
 
         self.assertEqual(result["total"], 1)
+        self.assertEqual(result["requested_limit"], 1)
+        self.assertEqual(result["applied_limit"], 1)
+        self.assertEqual(result["limit_cap"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
         self.assertEqual(
             result["items"][0]["creators"],
             [
@@ -597,12 +640,33 @@ class RecentItemsTests(DbTestCase):
             ],
         )
 
+    def test_get_recent_items_caps_requested_limit_and_reports_metadata(self):
+        zot = Mock()
+        zot.items.return_value = [self._paper_item()]
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.get_recent_items(limit=999))
+
+        self.assertEqual(result["requested_limit"], 999)
+        self.assertEqual(result["applied_limit"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertEqual(result["limit_cap"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertTrue(result["limit_capped"])
+        zot.items.assert_called_once_with(
+            limit=db._LIST_RESULT_LIMIT_CAP * 3,
+            sort="dateAdded",
+            direction="desc",
+        )
+
     def test_get_recent_items_returns_structured_error_skeleton_for_fetch_failure(self):
         with patch("zoty.db._get_zot", side_effect=RuntimeError("boom")):
             result = json.loads(db.get_recent_items(limit=1))
 
         self.assertEqual(result["items"], [])
         self.assertEqual(result["total"], 0)
+        self.assertEqual(result["requested_limit"], 1)
+        self.assertEqual(result["applied_limit"], 1)
+        self.assertEqual(result["limit_cap"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
         self.assertIn("Failed to fetch recent items: boom", result["error"])
 
 
@@ -803,6 +867,10 @@ class RecentItemsTests(DbTestCase):
             result = json.loads(db.get_recent_items(limit=1))
 
         self.assertEqual(result["total"], 1)
+        self.assertEqual(result["requested_limit"], 1)
+        self.assertEqual(result["applied_limit"], 1)
+        self.assertEqual(result["limit_cap"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
         self.assertEqual(result["items"][0]["key"], "ITEM1")
         self.assertEqual(
             result["items"][0]["attachments"],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -77,6 +77,16 @@ class ServerToolTests(unittest.TestCase):
             "Find which passages within one known item match a keyword query.",
         )
 
+    def test_list_and_recent_tool_docstrings_describe_fields_and_caps(self):
+        list_doc = " ".join(server.list_collection_items.__doc__.split())
+        recent_doc = " ".join(server.get_recent_items.__doc__.split())
+        self.assertIn("Requested items to return before the cap is applied", list_doc)
+        self.assertIn("JSON with `collection_key`, `collection_found`, `items`, and limit metadata.", list_doc)
+        self.assertIn("truncated `abstract` (500 chars)", list_doc)
+        self.assertIn("Requested items to return before the cap is applied", recent_doc)
+        self.assertIn("JSON with `items`, `total`, and limit metadata.", recent_doc)
+        self.assertIn("truncated `abstract` (500 chars)", recent_doc)
+
     def test_search_library_delegates_to_db(self):
         with patch.object(server.db, "search", return_value='{"results": []}') as db_mock:
             result = server.search_library(


### PR DESCRIPTION
Fixes #55
Fixes #70
Fixes #73

Summary:
- Add a shared cap for `list_collection_items` and `get_recent_items` with limit metadata matching the search response pattern
- Keep default limits intact while bounding oversized requests
- Expand tool docstrings so agents can see returned fields and abstract truncation

Validation:
- make test