### PR TITLE
fix: normalize item response shapes

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -42,6 +42,7 @@ _SEARCH_RESULT_LIMIT_CAP = 25
 _LIST_RESULT_LIMIT_CAP = 100
 _LIST_VIEW_MAX_CREATORS = 5
 _CITATION_EXPORT_MAX_WORKERS = 4
+_DETAIL_VIEW_MAX_CREATORS = 15
 _EMPTY_QUERY_WARNING = "Query produced no searchable terms after stop-word removal. Try more specific keywords."
 _LINK_MODE_LABELS = {
     0: "imported_file",
@@ -383,6 +384,7 @@ def _item_to_dict(
     item: dict,
     truncate_abstract: int = 0,
     *,
+    include_attachment_count: bool = False,
     include_attachments: bool = False,
     max_creators: int = -1,
 ) -> dict:
@@ -411,8 +413,13 @@ def _item_to_dict(
         "abstract": abstract,
     }
 
+    if include_attachment_count:
+        result["attachment_count"] = _get_item_attachment_count(data.get("key", ""))
+
     if include_attachments:
-        result["attachments"] = _get_item_attachments(data.get("key", ""))
+        attachments = _get_item_attachments(data.get("key", ""))
+        result["attachment_count"] = len(attachments)
+        result["attachments"] = attachments
 
     return result
 
@@ -430,7 +437,15 @@ def _empty_item_payload(item_key: str = "") -> dict[str, Any]:
         "tags": [],
         "collections": [],
         "abstract": "",
+        "attachment_count": 0,
         "attachments": [],
+    }
+
+
+def _empty_item_summary(item_key: str = "") -> dict[str, str]:
+    return {
+        "key": item_key,
+        "title": "",
     }
 
 
@@ -1658,7 +1673,8 @@ def _result_from_parent(
     score: float,
     best_doc: dict[str, Any],
     query_terms: list[str],
-    attachments: list[dict[str, Any]],
+    attachment_count: int,
+    attachments: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     result = {
         "key": parent["key"],
@@ -1671,10 +1687,11 @@ def _result_from_parent(
         "tags": list(parent["tags"]),
         "collections": list(parent["collections"]),
         "abstract": parent["abstract"][:500] + "..." if len(parent["abstract"]) > 500 else parent["abstract"],
-        "attachment_count": len(attachments),
-        "attachments": list(attachments),
+        "attachment_count": attachment_count,
         "score": round(score, 4),
     }
+    if attachments is not None:
+        result["attachments"] = list(attachments)
 
     if best_doc["doc_kind"] == "attachment_chunk":
         snippet = _snippet_from_text(best_doc["text"], query_terms)
@@ -1692,7 +1709,7 @@ def _result_from_parent(
 
 def _search_response(
     query: str,
-    results: list[dict[str, Any]],
+    items: list[dict[str, Any]],
     *,
     requested_limit: int,
     applied_limit: int,
@@ -1700,9 +1717,9 @@ def _search_response(
     warning: str | None = None,
 ) -> str:
     response: dict[str, Any] = {
-        "results": results,
+        "items": items,
         "query": query,
-        "total": len(results),
+        "total": len(items),
         "requested_limit": requested_limit,
         "applied_limit": applied_limit,
         "limit_cap": _SEARCH_RESULT_LIMIT_CAP,
@@ -1746,7 +1763,7 @@ def _result_from_doc(
 ) -> dict[str, Any]:
     snippet_source = doc["text"] if doc["doc_kind"] == "attachment_chunk" else (parent["abstract"] or doc["text"])
     result = {
-        "item_key": parent["key"],
+        "key": parent["key"],
         "title": parent["title"],
         "itemType": parent["itemType"],
         "score": round(score, 4),
@@ -1766,11 +1783,45 @@ def _result_from_doc(
     return result
 
 
+def _search_within_item_response(
+    *,
+    query: str,
+    matches: list[dict[str, Any]],
+    key: str | None = None,
+    item: dict[str, Any] | None = None,
+    item_keys: list[str] | None = None,
+    items: list[dict[str, Any]] | None = None,
+    missing_item_keys: list[str] | None = None,
+    error: str | None = None,
+    warning: str | None = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "matches": matches,
+        "query": query,
+        "total": len(matches),
+    }
+    if item_keys is not None:
+        payload["item_keys"] = list(item_keys)
+        payload["items"] = items or []
+        if missing_item_keys:
+            payload["missing_item_keys"] = list(missing_item_keys)
+    else:
+        normalized_key = key or ""
+        payload["key"] = normalized_key
+        payload["item"] = item or _empty_item_summary(normalized_key)
+    if error is not None:
+        payload["error"] = error
+    if warning is not None:
+        payload["warning"] = warning
+    return json.dumps(payload)
+
+
 def search(
     query: str,
     collection_key: str = "",
     item_type: str = "",
     limit: int = 10,
+    include_attachments: bool = False,
 ) -> str:
     """BM25 ranked search over titles, abstracts, and indexed attachment full text."""
     requested_limit = max(1, limit)
@@ -1886,14 +1937,23 @@ def search(
 
         batch_size = min(max_docs, batch_size * 2)
 
-    attachments_by_parent = _get_item_attachments_by_parent(list(best_by_parent))
+    if include_attachments:
+        attachments_by_parent = _get_item_attachments_by_parent(list(best_by_parent))
+        attachment_counts = {
+            parent_key: len(attachments_by_parent.get(parent_key, []))
+            for parent_key in best_by_parent
+        }
+    else:
+        attachment_counts = _get_item_attachment_counts(list(best_by_parent))
+        attachments_by_parent = {}
     results_payload = [
         _result_from_parent(
             state.parents[parent_key],
             score=score,
             best_doc=doc,
             query_terms=query_terms,
-            attachments=attachments_by_parent.get(parent_key, []),
+            attachment_count=attachment_counts.get(parent_key, 0),
+            attachments=attachments_by_parent.get(parent_key) if include_attachments else None,
         )
         for parent_key, (score, doc) in best_by_parent.items()
     ]
@@ -1928,13 +1988,12 @@ def search_within_item(
             unique_requested_keys.append(key)
 
     if not unique_requested_keys:
-        return json.dumps({
-            "error": "Provide item_key or item_keys",
-            "results": [],
-            "query": query,
-            "item_key": "",
-            "total": 0,
-        })
+        return _search_within_item_response(
+            key="",
+            query=query,
+            matches=[],
+            error="Provide item_key or item_keys",
+        )
 
     multi_item = len(unique_requested_keys) > 1
     normalized_item_key = unique_requested_keys[0]
@@ -1944,43 +2003,39 @@ def search_within_item(
 
     if state is None:
         if multi_item:
-            return json.dumps({
-                "error": "Index is still building, please retry in a moment",
-                "items": [],
-                "results": [],
-                "query": query,
-                "item_keys": unique_requested_keys,
-                "total": 0,
-            })
-        return json.dumps({
-            "error": "Index is still building, please retry in a moment",
-            "results": [],
-            "query": query,
-            "item_key": normalized_item_key,
-            "total": 0,
-        })
+            return _search_within_item_response(
+                query=query,
+                matches=[],
+                item_keys=unique_requested_keys,
+                items=[],
+                error="Index is still building, please retry in a moment",
+            )
+        return _search_within_item_response(
+            key=normalized_item_key,
+            query=query,
+            matches=[],
+            error="Index is still building, please retry in a moment",
+        )
 
     found_item_keys = [key for key in unique_requested_keys if key in state.parents]
     missing_item_keys = [key for key in unique_requested_keys if key not in state.parents]
 
     if not found_item_keys:
         if multi_item:
-            return json.dumps({
-                "error": "None of the requested item keys were found in the search index",
-                "items": [],
-                "results": [],
-                "query": query,
-                "item_keys": unique_requested_keys,
-                "missing_item_keys": missing_item_keys,
-                "total": 0,
-            })
-        return json.dumps({
-            "error": f"Item {normalized_item_key} was not found in the search index",
-            "results": [],
-            "query": query,
-            "item_key": normalized_item_key,
-            "total": 0,
-        })
+            return _search_within_item_response(
+                query=query,
+                matches=[],
+                item_keys=unique_requested_keys,
+                items=[],
+                missing_item_keys=missing_item_keys,
+                error="None of the requested item keys were found in the search index",
+            )
+        return _search_within_item_response(
+            key=normalized_item_key,
+            query=query,
+            matches=[],
+            error=f"Item {normalized_item_key} was not found in the search index",
+        )
 
     if multi_item:
         items_summary = [_item_summary_from_parent(state.parents[key]) for key in found_item_keys]
@@ -1988,24 +2043,27 @@ def search_within_item(
         item_summary = _item_summary_from_parent(state.parents[normalized_item_key])
 
     if state.retriever is None or not state.corpus_docs:
-        payload: dict[str, Any] = {
-            "results": [],
-            "query": query,
-            "total": 0,
-        }
         if multi_item:
-            payload["items"] = items_summary
-            payload["item_keys"] = found_item_keys
+            warning = None
             if missing_item_keys:
-                payload["warning"] = (
+                warning = (
                     "Some requested item keys were not found in the search index: "
                     + ", ".join(missing_item_keys)
                 )
-                payload["missing_item_keys"] = missing_item_keys
-        else:
-            payload["item"] = item_summary
-            payload["item_key"] = normalized_item_key
-        return json.dumps(payload)
+            return _search_within_item_response(
+                query=query,
+                matches=[],
+                item_keys=found_item_keys,
+                items=items_summary,
+                missing_item_keys=missing_item_keys,
+                warning=warning,
+            )
+        return _search_within_item_response(
+            key=normalized_item_key,
+            query=query,
+            matches=[],
+            item=item_summary,
+        )
 
     query_tokens = bm25s.tokenize(
         [query],
@@ -2021,22 +2079,22 @@ def search_within_item(
                 "Some requested item keys were not found in the search index: "
                 + ", ".join(missing_item_keys),
             )
-
-        payload = {
-            "results": [],
-            "query": query,
-            "total": 0,
-            "warning": " ".join(warnings),
-        }
         if multi_item:
-            payload["items"] = items_summary
-            payload["item_keys"] = found_item_keys
-            if missing_item_keys:
-                payload["missing_item_keys"] = missing_item_keys
-        else:
-            payload["item"] = item_summary
-            payload["item_key"] = normalized_item_key
-        return json.dumps(payload)
+            return _search_within_item_response(
+                query=query,
+                matches=[],
+                item_keys=found_item_keys,
+                items=items_summary,
+                missing_item_keys=missing_item_keys,
+                warning=" ".join(warnings),
+            )
+        return _search_within_item_response(
+            key=normalized_item_key,
+            query=query,
+            matches=[],
+            item=item_summary,
+            warning=_EMPTY_QUERY_WARNING,
+        )
 
     attachments_by_parent = _get_item_attachments_by_parent(found_item_keys)
     attachments_lookup_by_parent = {
@@ -2088,25 +2146,28 @@ def search_within_item(
 
         batch_size = min(max_docs, batch_size * 2)
 
-    payload = {
-        "results": matches[:limit],
-        "query": query,
-        "total": len(matches[:limit]),
-    }
     if multi_item:
-        payload["items"] = items_summary
-        payload["item_keys"] = found_item_keys
+        warning = None
         if missing_item_keys:
-            payload["warning"] = (
+            warning = (
                 "Some requested item keys were not found in the search index: "
                 + ", ".join(missing_item_keys)
             )
-            payload["missing_item_keys"] = missing_item_keys
-    else:
-        payload["item"] = item_summary
-        payload["item_key"] = normalized_item_key
+        return _search_within_item_response(
+            query=query,
+            matches=matches[:limit],
+            item_keys=found_item_keys,
+            items=items_summary,
+            missing_item_keys=missing_item_keys,
+            warning=warning,
+        )
 
-    return json.dumps(payload)
+    return _search_within_item_response(
+        key=normalized_item_key,
+        query=query,
+        matches=matches[:limit],
+        item=item_summary,
+    )
 
 
 def list_collections() -> str:
@@ -2188,7 +2249,7 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
             _item_to_dict(
                 item,
                 truncate_abstract=500,
-                include_attachments=True,
+                include_attachment_count=True,
                 max_creators=_LIST_VIEW_MAX_CREATORS,
             )
         )
@@ -2204,7 +2265,7 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
 
 def get_item(item_key: str) -> str:
     """Full metadata for a single item."""
-    normalized_item_key = item_key.strip()
+    normalized_item_key = item_key.strip().upper()
     if not normalized_item_key:
         payload = _empty_item_payload()
         payload["error"] = "Provide item_key"
@@ -2218,7 +2279,14 @@ def get_item(item_key: str) -> str:
         payload["error"] = f"Failed to fetch item {normalized_item_key}: {exc}"
         return json.dumps(payload)
 
-    return json.dumps(_item_to_dict(item, truncate_abstract=0, include_attachments=True))
+    return json.dumps(
+        _item_to_dict(
+            item,
+            truncate_abstract=0,
+            include_attachments=True,
+            max_creators=_DETAIL_VIEW_MAX_CREATORS,
+        )
+    )
 
 
 def get_bibtex_and_citation_for_items(
@@ -2312,7 +2380,7 @@ def get_recent_items(limit: int = 10) -> str:
         _item_to_dict(
             item,
             truncate_abstract=500,
-            include_attachments=True,
+            include_attachment_count=True,
             max_creators=_LIST_VIEW_MAX_CREATORS,
         )
         for item in items

--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -19,6 +19,7 @@ def search_library(
     collection_key: str = "",
     item_type: str = "",
     limit: int = 10,
+    include_attachments: bool = False,
 ) -> str:
     """Find which items in your Zotero library match a keyword query.
 
@@ -31,21 +32,23 @@ def search_library(
             (e.g. "journalArticle", "preprint", "conferencePaper", "book",
             "bookSection", "thesis", "report", "webpage")
         limit: Maximum results to return (default: 10)
+        include_attachments: Include resolved attachment metadata in each
+            returned item. Defaults to `False`; otherwise `attachment_count`
+            is still present without the heavier attachment array.
 
     Returns:
-        JSON with ranked search results including title, creators, date, score,
-        abstract text truncated to 500 characters, attachment_count, and
-        lightweight attachment details. Snippets are included when query terms
-        match either the best-ranked attachment chunk (with
-        snippet_attachment_key) or the abstract metadata. Invalid collection_key
-        and item_type filters return a warning instead of silently failing.
-        Response metadata includes requested/applied limits and cap details.
+        JSON with ranked Zotero items under `items`, including key, title,
+        creators, date, score, abstract text truncated to 500 characters,
+        `attachment_count`, optional `attachments` when
+        `include_attachments=True`, optional plain-text snippets, warnings for
+        invalid `collection_key` / `item_type` filters, and limit metadata.
     """
     return db.search(
         query,
         collection_key=collection_key,
         item_type=item_type,
         limit=limit,
+        include_attachments=include_attachments,
     )
 
 
@@ -71,9 +74,10 @@ def search_within_item(
         limit: Maximum number of passage matches to return (default: 5)
 
     Returns:
-        JSON with ranked passage matches, including snippets and attachment
-        context for chunk hits. Single-item calls return `item`; multi-item
-        calls return `items` and `item_keys`.
+        JSON with ranked passage `matches`, including snippets and attachment
+        context for chunk hits. Single-item calls return `key` and `item`;
+        multi-item calls return `item_keys` and `items`. Each match uses
+        `key` for the parent item.
     """
     return db.search_within_item(
         item_key=item_key,
@@ -104,7 +108,7 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
     Returns:
         JSON with `collection_key`, `collection_found`, `items`, and limit
         metadata. Each item includes `key`, `title`, `creators`, `date`,
-        truncated `abstract` (500 chars), `attachments`, and other summary
+        truncated `abstract` (500 chars), `attachment_count`, and other summary
         fields.
     """
     return db.list_collection_items(collection_key, limit=limit)
@@ -120,10 +124,12 @@ def get_item(item_key: str) -> str:
             results (for example, `X9KJ2M4P`).
 
     Returns:
-        JSON with complete item metadata including the full untruncated abstract,
-        title, creators, date, DOI, URL, tags, collections, and attachment
-        filepaths. Search results already include most fields, so use this only
-        when the full abstract is needed.
+        JSON with complete item metadata including the full untruncated
+        abstract, title, creators, date, DOI, URL, tags, collections,
+        attachment counts, and attachment filepaths. Very large creator lists
+        are summarized to keep the payload bounded. Search results already
+        include most fields, so use this only when the full abstract or full
+        attachment records are needed.
     """
     return db.get_item(item_key)
 
@@ -172,7 +178,7 @@ def get_recent_items(limit: int = 10) -> str:
     Returns:
         JSON with `items`, `total`, and limit metadata. Each item includes
         `key`, `title`, `creators`, `date`, truncated `abstract` (500 chars),
-        `attachments`, and other summary fields.
+        `attachment_count`, and other summary fields.
     """
     return db.get_recent_items(limit=limit)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -206,21 +206,31 @@ class AttachmentPathsTests(DbTestCase):
             result = json.loads(db.get_item("PARENT1"))
 
         self.assertEqual(result["key"], "PARENT1")
+        self.assertEqual(result["attachment_count"], 1)
         self.assertEqual(result["attachments"][0]["filepath"], str(db._ZOTERO_STORAGE / "ATTACH1" / "paper.pdf"))
         self.assertEqual(result["attachments"][0]["contentType"], "application/pdf")
 
-    def test_get_item_preserves_full_creator_list(self):
+    def test_get_item_normalizes_item_key_to_uppercase(self):
+        zot = Mock()
+        zot.item.return_value = self._paper_item()
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            json.loads(db.get_item(" parent1 "))
+
+        zot.item.assert_called_once_with("PARENT1")
+
+    def test_get_item_truncates_very_long_creator_lists(self):
         zot = Mock()
         item = self._paper_item()
-        item["data"]["creators"] = self._creator_dicts(7)
+        item["data"]["creators"] = self._creator_dicts(18)
         zot.item.return_value = item
 
         with patch("zoty.db._get_zot", return_value=zot):
             result = json.loads(db.get_item("PARENT1"))
 
-        self.assertEqual(len(result["creators"]), 7)
+        self.assertEqual(len(result["creators"]), db._DETAIL_VIEW_MAX_CREATORS + 1)
         self.assertEqual(result["creators"][0], "Author1 Example")
-        self.assertEqual(result["creators"][-1], "Author7 Example")
+        self.assertEqual(result["creators"][-1], "... and 3 more")
 
     def test_get_item_rejects_empty_item_key(self):
         with patch("zoty.db._get_zot") as get_zot_mock:
@@ -232,6 +242,7 @@ class AttachmentPathsTests(DbTestCase):
         self.assertEqual(result["creators"], [])
         self.assertEqual(result["tags"], [])
         self.assertEqual(result["collections"], [])
+        self.assertEqual(result["attachment_count"], 0)
         self.assertEqual(result["attachments"], [])
         get_zot_mock.assert_not_called()
 
@@ -245,6 +256,7 @@ class AttachmentPathsTests(DbTestCase):
         self.assertEqual(result["creators"], [])
         self.assertEqual(result["tags"], [])
         self.assertEqual(result["collections"], [])
+        self.assertEqual(result["attachment_count"], 0)
         self.assertEqual(result["attachments"], [])
         get_zot_mock.assert_not_called()
 
@@ -260,6 +272,7 @@ class AttachmentPathsTests(DbTestCase):
         self.assertEqual(result["creators"], [])
         self.assertEqual(result["tags"], [])
         self.assertEqual(result["collections"], [])
+        self.assertEqual(result["attachment_count"], 0)
         self.assertEqual(result["attachments"], [])
         self.assertIn("Failed to fetch item PARENT1: boom", result["error"])
 
@@ -289,21 +302,10 @@ class AttachmentPathsTests(DbTestCase):
         result = json.loads(db.search("example"))
 
         self.assertEqual(result["total"], 1)
-        self.assertEqual(result["results"][0]["key"], "PARENT1")
-        self.assertEqual(result["results"][0]["attachment_count"], 1)
-        self.assertEqual(
-            result["results"][0]["attachments"],
-            [
-                {
-                    "key": "ATTACH1",
-                    "title": "Attached PDF",
-                    "contentType": "application/pdf",
-                    "linkMode": "imported_file",
-                    "filepath": str(db._ZOTERO_STORAGE / "ATTACH1" / "paper.pdf"),
-                }
-            ],
-        )
-        self.assertEqual(result["results"][0]["snippet_attachment_key"], "ATTACH1")
+        self.assertEqual(result["items"][0]["key"], "PARENT1")
+        self.assertEqual(result["items"][0]["attachment_count"], 1)
+        self.assertNotIn("attachments", result["items"][0])
+        self.assertEqual(result["items"][0]["snippet_attachment_key"], "ATTACH1")
 
     def test_search_batches_attachment_detail_lookups_for_multiple_results(self):
         with closing(sqlite3.connect(db._ZOTERO_DB)) as conn:
@@ -387,17 +389,17 @@ class AttachmentPathsTests(DbTestCase):
         self._install_search_state(docs, parents=parents)
 
         with patch("zoty.db._open_zotero_db", wraps=db._open_zotero_db) as open_db_mock:
-            result = json.loads(db.search("example", limit=2))
+            result = json.loads(db.search("example", limit=2, include_attachments=True))
 
         self.assertEqual(result["total"], 2)
-        self.assertEqual([row["key"] for row in result["results"]], ["PARENT1", "PARENT2"])
-        self.assertEqual([row["attachment_count"] for row in result["results"]], [1, 1])
+        self.assertEqual([row["key"] for row in result["items"]], ["PARENT1", "PARENT2"])
+        self.assertEqual([row["attachment_count"] for row in result["items"]], [1, 1])
         self.assertEqual(
-            result["results"][0]["attachments"][0]["filepath"],
+            result["items"][0]["attachments"][0]["filepath"],
             str(db._ZOTERO_STORAGE / "ATTACH1" / "paper.pdf"),
         )
         self.assertEqual(
-            result["results"][1]["attachments"][0]["filepath"],
+            result["items"][1]["attachments"][0]["filepath"],
             str(db._ZOTERO_STORAGE / "ATTACH2" / "book.epub"),
         )
         self.assertEqual(open_db_mock.call_count, 1)
@@ -549,18 +551,8 @@ class CollectionItemTests(DbTestCase):
         self.assertFalse(result["limit_capped"])
         self.assertEqual([row["key"] for row in result["items"]], ["ITEM1"])
         self.assertEqual(result["items"][0]["title"], "First Paper")
-        self.assertEqual(
-            result["items"][0]["attachments"],
-            [
-                {
-                    "key": "ATTACH1",
-                    "title": "Collection PDF",
-                    "contentType": "application/pdf",
-                    "linkMode": "imported_file",
-                    "filepath": str(db._ZOTERO_STORAGE / "ATTACH1" / "collection.pdf"),
-                }
-            ],
-        )
+        self.assertEqual(result["items"][0]["attachment_count"], 1)
+        self.assertNotIn("attachments", result["items"][0])
         zot.collection_items.assert_called_once_with("COLL123", limit=5)
 
     def test_list_collection_items_caps_requested_limit_and_reports_metadata(self):
@@ -849,7 +841,7 @@ class RecentItemsTests(DbTestCase):
             )
             conn.commit()
 
-    def test_get_recent_items_includes_attachments(self):
+    def test_get_recent_items_includes_attachment_count(self):
         zot = Mock()
         zot.items.return_value = [
             {
@@ -891,18 +883,8 @@ class RecentItemsTests(DbTestCase):
         self.assertEqual(result["limit_cap"], db._LIST_RESULT_LIMIT_CAP)
         self.assertFalse(result["limit_capped"])
         self.assertEqual(result["items"][0]["key"], "ITEM1")
-        self.assertEqual(
-            result["items"][0]["attachments"],
-            [
-                {
-                    "key": "ATTACH1",
-                    "title": "Recent PDF",
-                    "contentType": "application/pdf",
-                    "linkMode": "imported_file",
-                    "filepath": str(db._ZOTERO_STORAGE / "ATTACH1" / "recent.pdf"),
-                }
-            ],
-        )
+        self.assertEqual(result["items"][0]["attachment_count"], 1)
+        self.assertNotIn("attachments", result["items"][0])
         zot.items.assert_called_once_with(limit=3, sort="dateAdded", direction="desc")
 
 
@@ -978,7 +960,7 @@ class SearchBehaviorTests(DbTestCase):
         result = json.loads(db.search("body only"))
 
         self.assertEqual(result["error"], "Index is still building, please retry in a moment")
-        self.assertEqual(result["results"], [])
+        self.assertEqual(result["items"], [])
 
     def test_body_only_query_returns_parent_with_attachment_snippet(self):
         attachment_doc = {
@@ -998,9 +980,9 @@ class SearchBehaviorTests(DbTestCase):
         result = json.loads(db.search("meatpotatoes"))
 
         self.assertEqual(result["total"], 1)
-        self.assertEqual(result["results"][0]["key"], "PARENT1")
-        self.assertIn("meatpotatoes", result["results"][0]["snippet"].lower())
-        self.assertEqual(result["results"][0]["snippet_attachment_key"], "ATTACH1")
+        self.assertEqual(result["items"][0]["key"], "PARENT1")
+        self.assertIn("meatpotatoes", result["items"][0]["snippet"].lower())
+        self.assertEqual(result["items"][0]["snippet_attachment_key"], "ATTACH1")
 
     def test_search_truncates_long_creator_lists(self):
         attachment_doc = {
@@ -1035,7 +1017,7 @@ class SearchBehaviorTests(DbTestCase):
         result = json.loads(db.search("meatpotatoes"))
 
         self.assertEqual(
-            result["results"][0]["creators"],
+            result["items"][0]["creators"],
             [
                 "Author 1",
                 "Author 2",
@@ -1064,9 +1046,9 @@ class SearchBehaviorTests(DbTestCase):
         result = json.loads(db.search("novelty"))
 
         self.assertEqual(result["total"], 1)
-        self.assertEqual(result["results"][0]["key"], "PARENT1")
-        self.assertIn("example abstract", result["results"][0]["snippet"].lower())
-        self.assertNotIn("snippet_attachment_key", result["results"][0])
+        self.assertEqual(result["items"][0]["key"], "PARENT1")
+        self.assertIn("example abstract", result["items"][0]["snippet"].lower())
+        self.assertNotIn("snippet_attachment_key", result["items"][0])
 
     def test_multiple_matching_chunks_collapse_to_one_parent(self):
         parents = {
@@ -1140,8 +1122,8 @@ class SearchBehaviorTests(DbTestCase):
         result = json.loads(db.search("shared"))
 
         self.assertEqual(result["total"], 2)
-        self.assertEqual([row["key"] for row in result["results"]], ["PARENT1", "PARENT2"])
-        self.assertEqual(result["results"][0]["score"], 9.0)
+        self.assertEqual([row["key"] for row in result["items"]], ["PARENT1", "PARENT2"])
+        self.assertEqual(result["items"][0]["score"], 9.0)
 
     def test_collection_and_item_type_filters_apply_at_parent_level(self):
         parents = {
@@ -1203,7 +1185,7 @@ class SearchBehaviorTests(DbTestCase):
         result = json.loads(db.search("query", collection_key="KEEP", item_type="preprint"))
 
         self.assertEqual(result["total"], 1)
-        self.assertEqual(result["results"][0]["key"], "PARENT1")
+        self.assertEqual(result["items"][0]["key"], "PARENT1")
 
     def test_search_warns_for_unknown_collection_key_filter(self):
         self._install_search_state([
@@ -1223,7 +1205,7 @@ class SearchBehaviorTests(DbTestCase):
 
         result = json.loads(db.search("query", collection_key="missing"))
 
-        self.assertEqual(result["results"], [])
+        self.assertEqual(result["items"], [])
         self.assertEqual(result["total"], 0)
         self.assertEqual(
             result["warning"],
@@ -1248,7 +1230,7 @@ class SearchBehaviorTests(DbTestCase):
 
         result = json.loads(db.search("query", item_type="invalidType"))
 
-        self.assertEqual(result["results"], [])
+        self.assertEqual(result["items"], [])
         self.assertEqual(result["total"], 0)
         self.assertEqual(
             result["warning"],
@@ -1299,9 +1281,9 @@ class SearchBehaviorTests(DbTestCase):
         self.assertEqual(result["limit_cap"], db._SEARCH_RESULT_LIMIT_CAP)
         self.assertTrue(result["limit_capped"])
         self.assertEqual(result["total"], db._SEARCH_RESULT_LIMIT_CAP)
-        self.assertEqual(len(result["results"]), db._SEARCH_RESULT_LIMIT_CAP)
+        self.assertEqual(len(result["items"]), db._SEARCH_RESULT_LIMIT_CAP)
         self.assertEqual([call["k"] for call in db._search_state.retriever.calls], [500])
-        self.assertEqual(result["results"][0]["key"], "PARENT1")
+        self.assertEqual(result["items"][0]["key"], "PARENT1")
 
     def test_search_returns_warning_when_query_has_no_searchable_terms(self):
         self._install_search_state([
@@ -1321,7 +1303,7 @@ class SearchBehaviorTests(DbTestCase):
 
         result = json.loads(db.search("the and or", limit=3))
 
-        self.assertEqual(result["results"], [])
+        self.assertEqual(result["items"], [])
         self.assertEqual(result["total"], 0)
         self.assertEqual(result["warning"], db._EMPTY_QUERY_WARNING)
         self.assertEqual(db._search_state.retriever.calls, [])
@@ -1344,7 +1326,7 @@ class SearchBehaviorTests(DbTestCase):
 
         result = json.loads(db.search("quantum topology", limit=3))
 
-        self.assertEqual(result["results"], [])
+        self.assertEqual(result["items"], [])
         self.assertEqual(result["total"], 0)
         self.assertNotIn("warning", result)
 
@@ -1431,18 +1413,18 @@ class SearchBehaviorTests(DbTestCase):
 
         result = json.loads(db.search_within_item("parent1", "query", limit=3))
 
-        self.assertEqual(result["item_key"], "PARENT1")
+        self.assertEqual(result["key"], "PARENT1")
         self.assertEqual(result["item"], {"key": "PARENT1", "title": "First Paper"})
         self.assertNotIn("abstract", result["item"])
         self.assertNotIn("attachments", result["item"])
         self.assertEqual(result["total"], 3)
         self.assertEqual(
-            [row["match_type"] for row in result["results"]],
+            [row["match_type"] for row in result["matches"]],
             ["attachment_chunk", "attachment_chunk", "metadata"],
         )
-        self.assertEqual(result["results"][0]["attachment_key"], "ATTACH1")
-        self.assertEqual(result["results"][1]["attachment_key"], "ATTACH2")
-        self.assertNotIn("attachment_key", result["results"][2])
+        self.assertEqual(result["matches"][0]["attachment_key"], "ATTACH1")
+        self.assertEqual(result["matches"][1]["attachment_key"], "ATTACH2")
+        self.assertNotIn("attachment_key", result["matches"][2])
 
     def test_search_within_item_returns_lean_item_summary_when_query_has_no_terms(self):
         self._install_search_state([
@@ -1463,7 +1445,7 @@ class SearchBehaviorTests(DbTestCase):
         result = json.loads(db.search_within_item("parent1", "the and", limit=3))
 
         self.assertEqual(result["item"], {"key": "PARENT1", "title": "Example Paper"})
-        self.assertEqual(result["results"], [])
+        self.assertEqual(result["matches"], [])
         self.assertEqual(result["total"], 0)
         self.assertEqual(result["warning"], db._EMPTY_QUERY_WARNING)
         self.assertEqual(db._search_state.retriever.calls, [])
@@ -1487,7 +1469,7 @@ class SearchBehaviorTests(DbTestCase):
         result = json.loads(db.search_within_item("parent1", "quantum topology", limit=3))
 
         self.assertEqual(result["item"], {"key": "PARENT1", "title": "Example Paper"})
-        self.assertEqual(result["results"], [])
+        self.assertEqual(result["matches"], [])
         self.assertEqual(result["total"], 0)
         self.assertNotIn("warning", result)
 
@@ -1509,8 +1491,9 @@ class SearchBehaviorTests(DbTestCase):
 
         result = json.loads(db.search_within_item("missing", "query"))
 
-        self.assertEqual(result["item_key"], "MISSING")
-        self.assertEqual(result["results"], [])
+        self.assertEqual(result["key"], "MISSING")
+        self.assertEqual(result["item"], {"key": "MISSING", "title": ""})
+        self.assertEqual(result["matches"], [])
         self.assertIn("was not found", result["error"])
 
     def test_search_within_item_supports_multi_item_queries(self):
@@ -1588,7 +1571,7 @@ class SearchBehaviorTests(DbTestCase):
             ],
         )
         self.assertEqual(result["total"], 2)
-        self.assertEqual([row["item_key"] for row in result["results"]], ["PARENT2", "PARENT1"])
+        self.assertEqual([row["key"] for row in result["matches"]], ["PARENT2", "PARENT1"])
 
 
 class SnapshotLifecycleTests(DbTestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -88,31 +88,33 @@ class ServerToolTests(unittest.TestCase):
         self.assertIn("truncated `abstract` (500 chars)", recent_doc)
 
     def test_search_library_delegates_to_db(self):
-        with patch.object(server.db, "search", return_value='{"results": []}') as db_mock:
+        with patch.object(server.db, "search", return_value='{"items": []}') as db_mock:
             result = server.search_library(
                 query="transformer attention",
                 collection_key="COLL123",
                 item_type="preprint",
                 limit=5,
+                include_attachments=True,
             )
 
-        self.assertEqual(result, '{"results": []}')
+        self.assertEqual(result, '{"items": []}')
         db_mock.assert_called_once_with(
             "transformer attention",
             collection_key="COLL123",
             item_type="preprint",
             limit=5,
+            include_attachments=True,
         )
 
     def test_search_library_docstring_mentions_snippet_and_abstract_behavior(self):
         doc = server.search_library.__doc__ or ""
 
         self.assertIn("abstract text truncated to 500 characters", doc)
-        self.assertIn("snippet_attachment_key", doc)
-        self.assertIn("Invalid collection_key", doc)
+        self.assertIn("include_attachments", doc)
+        self.assertIn("invalid `collection_key` / `item_type` filters", doc)
 
     def test_search_within_item_delegates_to_db(self):
-        with patch.object(server.db, "search_within_item", return_value='{"results": []}') as db_mock:
+        with patch.object(server.db, "search_within_item", return_value='{"matches": []}') as db_mock:
             result = server.search_within_item(
                 item_key="ITEM123",
                 item_keys=["ITEM456"],
@@ -120,13 +122,19 @@ class ServerToolTests(unittest.TestCase):
                 limit=5,
             )
 
-        self.assertEqual(result, '{"results": []}')
+        self.assertEqual(result, '{"matches": []}')
         db_mock.assert_called_once_with(
             item_key="ITEM123",
             item_keys=["ITEM456"],
             query="transformer attention",
             limit=5,
         )
+
+    def test_response_shape_docstrings_reflect_canonical_keys(self):
+        self.assertIn("under `items`", server.search_library.__doc__)
+        self.assertIn("`matches`", server.search_within_item.__doc__)
+        self.assertIn("attachment_count", server.list_collection_items.__doc__)
+        self.assertIn("attachment_count", server.get_recent_items.__doc__)
 
     def test_get_bibtex_and_citation_for_items_delegates_to_db(self):
         with patch.object(server.db, "get_bibtex_and_citation_for_items", return_value='{"items": []}') as db_mock:


### PR DESCRIPTION
## Summary
- standardize item-list responses around `items`, passage search around `matches`, and item context around `key`
- make summary/list views expose `attachment_count` while reserving full attachment records for `get_item`
- normalize `get_item` keys to uppercase, cap very large creator lists, and align tool descriptions/tests with the new contract

## Testing
- make test

Fixes #57
Fixes #58
Fixes #59
Fixes #65
Fixes #74
Fixes #76