### PR TITLE
fix(security): secure Zotero storage directory keys

### DIFF
--- a/src/zoty/connector.py
+++ b/src/zoty/connector.py
@@ -10,7 +10,7 @@ from collections import deque
 from contextlib import closing
 import json
 import os
-import random
+import secrets
 import sqlite3
 import string
 import sys
@@ -281,7 +281,7 @@ def _add_paper_error_payload(error: str, *, collection_key: str = "") -> dict[st
 
 def _zotero_key(length: int = 8) -> str:
     chars = string.ascii_uppercase + string.digits
-    return "".join(random.choices(chars, k=length))
+    return "".join(secrets.choice(chars) for _ in range(length))
 
 
 def _read_response_text(req: urllib.request.Request, *, timeout: int) -> str:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -266,6 +266,21 @@ class DownloadPdfSecurityTests(unittest.TestCase):
                 close_mock.assert_called_once_with(17)
 
 
+class ZoteroKeySecurityTests(unittest.TestCase):
+    @patch("zoty.connector.secrets.choice", side_effect=list("ABCD1234"))
+    def test_zotero_key_uses_secrets_choice_per_character(self, choice_mock):
+        key = connector._zotero_key()
+
+        self.assertEqual(key, "ABCD1234")
+        self.assertEqual(choice_mock.call_count, 8)
+        self.assertTrue(
+            all(
+                call.args[0] == connector.string.ascii_uppercase + connector.string.digits
+                for call in choice_mock.call_args_list
+            )
+        )
+
+
 class CollectionAssignmentRetryTests(unittest.TestCase):
     @patch("zoty.connector.time.sleep", autospec=True)
     def test_retries_bridge_http_400(self, sleep_mock):


### PR DESCRIPTION
Fixes #85.

Use `secrets.choice()` instead of `random.choices()` when generating Zotero storage directory names, and add a regression test that verifies the secure generator is used per character.

Tests:
- `uv run python -m unittest discover -s tests -v`