### PR TITLE
Fix attachment helper error logging (#84)

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -264,6 +264,10 @@ def _resolve_attachment_filepath(attachment_key: str, raw_path: str) -> str:
     return stored_path
 
 
+def _log_attachment_helper_error(message: str, exc: Exception) -> None:
+    print(f"zoty: {message}: {exc}", file=sys.stderr)
+
+
 def _get_item_attachments_by_parent(item_keys: list[str]) -> dict[str, list[dict[str, Any]]]:
     """Return attachment metadata for each requested parent item key."""
     normalized_keys: list[str] = []
@@ -298,7 +302,11 @@ def _get_item_attachments_by_parent(item_keys: list[str]) -> dict[str, list[dict
                     ORDER BY parent.key ASC, child.dateAdded ASC""",
                 normalized_keys,
             ).fetchall()
-    except Exception:
+    except Exception as exc:
+        _log_attachment_helper_error(
+            f"failed to load attachment metadata for {', '.join(normalized_keys)}",
+            exc,
+        )
         return attachments_by_parent
 
     for row in rows:
@@ -341,7 +349,8 @@ def _get_item_attachment_count(item_key: str) -> int:
                    WHERE parent.key = ?""",
                 (key,),
             ).fetchone()
-    except Exception:
+    except Exception as exc:
+        _log_attachment_helper_error(f"failed to count attachments for {key}", exc)
         return 0
 
     return int(row["count"]) if row else 0
@@ -371,7 +380,11 @@ def _get_item_attachment_counts(item_keys: list[str]) -> dict[str, int]:
                     GROUP BY parent.key""",
                 normalized_keys,
             ).fetchall()
-    except Exception:
+    except Exception as exc:
+        _log_attachment_helper_error(
+            f"failed to count attachments for {', '.join(normalized_keys)}",
+            exc,
+        )
         return counts
 
     for row in rows:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,3 +1,4 @@
+import io
 import json
 import sqlite3
 import tempfile
@@ -189,6 +190,42 @@ class AttachmentPathsTests(DbTestCase):
                 }
             ],
         )
+
+    def test_get_item_attachments_by_parent_logs_and_falls_back_on_failure(self):
+        stderr = io.StringIO()
+
+        with (
+            patch("zoty.db._open_zotero_db", side_effect=RuntimeError("boom")),
+            patch("sys.stderr", new=stderr),
+        ):
+            attachments_by_parent = db._get_item_attachments_by_parent(["PARENT1"])
+
+        self.assertEqual(attachments_by_parent, {"PARENT1": []})
+        self.assertIn("zoty: failed to load attachment metadata for PARENT1: boom", stderr.getvalue())
+
+    def test_get_item_attachment_count_logs_and_falls_back_on_failure(self):
+        stderr = io.StringIO()
+
+        with (
+            patch("zoty.db._open_zotero_db", side_effect=RuntimeError("boom")),
+            patch("sys.stderr", new=stderr),
+        ):
+            count = db._get_item_attachment_count("PARENT1")
+
+        self.assertEqual(count, 0)
+        self.assertIn("zoty: failed to count attachments for PARENT1: boom", stderr.getvalue())
+
+    def test_get_item_attachment_counts_logs_and_falls_back_on_failure(self):
+        stderr = io.StringIO()
+
+        with (
+            patch("zoty.db._open_zotero_db", side_effect=RuntimeError("boom")),
+            patch("sys.stderr", new=stderr),
+        ):
+            counts = db._get_item_attachment_counts(["PARENT1", " PARENT2 ", "PARENT1"])
+
+        self.assertEqual(counts, {"PARENT1": 0, "PARENT2": 0})
+        self.assertIn("zoty: failed to count attachments for PARENT1, PARENT2: boom", stderr.getvalue())
 
     def test_format_link_mode_maps_known_and_unknown_values(self):
         self.assertEqual(db._format_link_mode(0), "imported_file")


### PR DESCRIPTION
## Summary\n- Log attachment helper failures to stderr instead of swallowing them silently.\n- Preserve the existing safe fallback return values for attachment lookups and counts.\n- Add tests that cover the error logs and fallback outputs.\n\n## Verification\n- uv run python -m unittest discover -s tests -v\n\nCloses #84