### PR TITLE
Clarify search_within_item attachment chunk fields

### DIFF
--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -74,10 +74,13 @@ def search_within_item(
         limit: Maximum number of passage matches to return (default: 5)
 
     Returns:
-        JSON with ranked passage `matches`, including snippets and attachment
-        context for chunk hits. Single-item calls return `key` and `item`;
-        multi-item calls return `item_keys` and `items`. Each match uses
-        `key` for the parent item.
+        JSON with ranked passage `matches`, including `snippet`, `chunk_index`,
+        `char_start`, and `char_end` for every hit. When a match comes from an
+        attachment chunk, it also includes `attachment_key`,
+        `attachment_title`, and `attachment_filepath` so you can identify the
+        source file for that passage. Single-item calls return `key` and `item`;
+        multi-item calls return `item_keys` and `items`. Each match uses `key`
+        for the parent item.
     """
     return db.search_within_item(
         item_key=item_key,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -130,9 +130,27 @@ class ServerToolTests(unittest.TestCase):
             limit=5,
         )
 
+    def test_search_within_item_tool_description_mentions_attachment_chunk_fields(self):
+        async def get_tool_description():
+            tools = await server.mcp_server.list_tools()
+            for tool in tools:
+                if tool.name == "search_within_item":
+                    return tool.description
+            self.fail("search_within_item tool was not registered")
+
+        description = asyncio.run(get_tool_description())
+
+        self.assertIn("attachment_key", description)
+        self.assertIn("attachment_title", description)
+        self.assertIn("attachment_filepath", description)
+        self.assertIn("chunk_index", description)
+        self.assertIn("char_start", description)
+        self.assertIn("char_end", description)
+
     def test_response_shape_docstrings_reflect_canonical_keys(self):
         self.assertIn("under `items`", server.search_library.__doc__)
         self.assertIn("`matches`", server.search_within_item.__doc__)
+        self.assertIn("attachment_key", server.search_within_item.__doc__)
         self.assertIn("attachment_count", server.list_collection_items.__doc__)
         self.assertIn("attachment_count", server.get_recent_items.__doc__)
 


### PR DESCRIPTION
## Summary
- Make the `search_within_item` tool description explicit about chunk-hit attachment context fields.
- Add a server test that asserts the registered tool description includes the attachment-specific fields.

## Verification
- `uv run python -m unittest discover -s tests -v`

Closes #66