### PR TITLE
Fix redundant search_within_item match fields (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The bridge runs an HTTP server on `localhost:24119` when Zotero is open. No conf
 | Tool | Description |
 |------|-------------|
 | `search_library` | Find which items in your Zotero library match a keyword query, ranked by BM25 over title, abstract, and indexed attachment full text, with optional plain-text snippets, attachment counts, collection filtering, and case-insensitive item type values like `journalArticle`, `preprint`, `conferencePaper`, `book`, `bookSection`, `thesis`, `report`, and `webpage` |
-| `search_within_item` | Find which passages within one known item match a keyword query, using `search_library` results to drill into a specific paper while returning ranked metadata or attachment-chunk matches with snippets and attachment context |
+| `search_within_item` | Find which passages within one or more known items match a keyword query, using `search_library` results to drill into a specific paper or compare several papers; top-level item summaries carry parent titles, and per-match parent `key` is only repeated for multi-item ranking |
 | `list_collections` | List all collections with keys, names, and item counts |
 | `list_collection_items` | List items in a specific collection |
 | `get_item` | Full metadata for a single item by `key`; use the `key` field from `search_library`, `list_collection_items`, or `get_recent_items` results. It includes the full untruncated abstract and attachment filepaths, so use it when the full abstract is needed |

--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -1780,11 +1780,10 @@ def _result_from_doc(
     doc: dict[str, Any],
     query_terms: list[str],
     attachments_by_key: dict[str, dict[str, Any]],
+    include_parent_key: bool,
 ) -> dict[str, Any]:
     snippet_source = doc["text"] if doc["doc_kind"] == "attachment_chunk" else (parent["abstract"] or doc["text"])
     result = {
-        "key": parent["key"],
-        "title": parent["title"],
         "itemType": parent["itemType"],
         "score": round(score, 4),
         "match_type": doc["doc_kind"],
@@ -1793,6 +1792,8 @@ def _result_from_doc(
         "char_start": doc["char_start"],
         "char_end": doc["char_end"],
     }
+    if include_parent_key:
+        result["key"] = parent["key"]
 
     if doc["doc_kind"] == "attachment_chunk":
         attachment = attachments_by_key.get(doc["attachment_key"], {})
@@ -2155,6 +2156,7 @@ def search_within_item(
                 doc=doc,
                 query_terms=query_terms,
                 attachments_by_key=attachments_lookup_by_parent.get(parent_key, {}),
+                include_parent_key=multi_item,
             ))
 
             if len(matches) >= limit:

--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -74,13 +74,14 @@ def search_within_item(
         limit: Maximum number of passage matches to return (default: 5)
 
     Returns:
-        JSON with ranked passage `matches`, including `snippet`, `chunk_index`,
-        `char_start`, and `char_end` for every hit. When a match comes from an
-        attachment chunk, it also includes `attachment_key`,
-        `attachment_title`, and `attachment_filepath` so you can identify the
-        source file for that passage. Single-item calls return `key` and `item`;
-        multi-item calls return `item_keys` and `items`. Each match uses `key`
-        for the parent item.
+        JSON with ranked passage `matches`, including `snippet`,
+        `chunk_index`, `char_start`, and `char_end` for every hit. When a
+        match comes from an attachment chunk, it also includes
+        `attachment_key`, `attachment_title`, and `attachment_filepath` so you
+        can identify the source file for that passage. Single-item calls
+        return `key` and `item`; multi-item calls return `item_keys` and
+        `items`. Matches omit the redundant parent title and include parent
+        `key` only for multi-item calls.
     """
     return db.search_within_item(
         item_key=item_key,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1528,6 +1528,8 @@ class SearchBehaviorTests(DbTestCase):
             [row["match_type"] for row in result["matches"]],
             ["attachment_chunk", "attachment_chunk", "metadata"],
         )
+        self.assertNotIn("key", result["matches"][0])
+        self.assertNotIn("title", result["matches"][0])
         self.assertEqual(result["matches"][0]["attachment_key"], "ATTACH1")
         self.assertEqual(result["matches"][1]["attachment_key"], "ATTACH2")
         self.assertNotIn("attachment_key", result["matches"][2])
@@ -1678,6 +1680,8 @@ class SearchBehaviorTests(DbTestCase):
         )
         self.assertEqual(result["total"], 2)
         self.assertEqual([row["key"] for row in result["matches"]], ["PARENT2", "PARENT1"])
+        self.assertNotIn("title", result["matches"][0])
+        self.assertNotIn("title", result["matches"][1])
 
 
 class SnapshotLifecycleTests(DbTestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -148,9 +148,11 @@ class ServerToolTests(unittest.TestCase):
         self.assertIn("char_end", description)
 
     def test_response_shape_docstrings_reflect_canonical_keys(self):
+        search_within_doc = " ".join(server.search_within_item.__doc__.split())
         self.assertIn("under `items`", server.search_library.__doc__)
         self.assertIn("`matches`", server.search_within_item.__doc__)
         self.assertIn("attachment_key", server.search_within_item.__doc__)
+        self.assertIn("include parent `key` only for multi-item calls", search_within_doc)
         self.assertIn("attachment_count", server.list_collection_items.__doc__)
         self.assertIn("attachment_count", server.get_recent_items.__doc__)
 


### PR DESCRIPTION
## Summary
- drop redundant per-match parent titles from `search_within_item` results
- include parent `key` on each match only for multi-item queries, where cross-item ranking needs it
- update tests and README/docstrings to reflect the new response shape

## Testing
- uv run python -m unittest discover -s tests -v

Closes #67.