### PR TITLE
Fix #79: add batch support to get_item

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The bridge runs an HTTP server on `localhost:24119` when Zotero is open. No conf
 | `search_within_item` | Find which passages within one known item match a keyword query, using `search_library` results to drill into a specific paper while returning ranked metadata or attachment-chunk matches with snippets and attachment context |
 | `list_collections` | List all collections with keys, names, and item counts |
 | `list_collection_items` | List items in a specific collection |
-| `get_item` | Full metadata for a single item by `key`; use the `key` field from `search_library`, `list_collection_items`, or `get_recent_items` results. It includes the full untruncated abstract and attachment filepaths, so use it when the full abstract is needed |
+| `get_item` | Full metadata for a single `item_key` or batch `item_keys`; use the `key` field from `search_library`, `list_collection_items`, or `get_recent_items` results. Single-key requests keep the existing item payload, while batch requests return `items` plus optional per-item `errors` |
 | `get_bibtex_and_citation_for_items` | BibTeX plus formatted citation and bibliography text for a single `item_key` or batch `item_keys`; use the `key` field from `search_library`, `list_collection_items`, or `get_recent_items` results. Both can be combined and at least one must be provided |
 | `get_recent_items` | Recently added items, sorted by date |
 | `add_paper` | Add a paper by arXiv ID or DOI with automatic PDF download and collection-scoped duplicate prevention |

--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -42,6 +42,7 @@ _SEARCH_RESULT_LIMIT_CAP = 25
 _LIST_RESULT_LIMIT_CAP = 100
 _LIST_VIEW_MAX_CREATORS = 5
 _CITATION_EXPORT_MAX_WORKERS = 4
+_ITEM_DETAIL_MAX_WORKERS = 4
 _DETAIL_VIEW_MAX_CREATORS = 15
 _EMPTY_QUERY_WARNING = "Query produced no searchable terms after stop-word removal. Try more specific keywords."
 _LINK_MODE_LABELS = {
@@ -406,6 +407,8 @@ def _item_to_dict(
     include_attachment_count: bool = False,
     include_attachments: bool = False,
     max_creators: int = -1,
+    attachments: list[dict[str, Any]] | None = None,
+    attachment_count: int | None = None,
 ) -> dict:
     """Convert a pyzotero item to a concise dict for tool output."""
     data = item.get("data", {})
@@ -433,12 +436,16 @@ def _item_to_dict(
     }
 
     if include_attachment_count:
-        result["attachment_count"] = _get_item_attachment_count(data.get("key", ""))
+        if attachment_count is None:
+            attachment_count = _get_item_attachment_count(data.get("key", ""))
+        result["attachment_count"] = attachment_count
 
     if include_attachments:
-        attachments = _get_item_attachments(data.get("key", ""))
-        result["attachment_count"] = len(attachments)
-        result["attachments"] = attachments
+        resolved_attachments = attachments
+        if resolved_attachments is None:
+            resolved_attachments = _get_item_attachments(data.get("key", ""))
+        result["attachment_count"] = len(resolved_attachments)
+        result["attachments"] = resolved_attachments
 
     return result
 
@@ -481,6 +488,11 @@ def _normalize_item_keys(item_key: str = "", item_keys: list[str] | None = None)
             normalized.append(cleaned)
 
     return normalized
+
+
+def _fetch_item_detail(item_key: str) -> dict[str, Any]:
+    """Fetch one Zotero item detail payload."""
+    return _get_zot().item(item_key)
 
 
 def _xhtml_to_text(fragment: str) -> str:
@@ -2283,30 +2295,78 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
     })
 
 
-def get_item(item_key: str) -> str:
-    """Full metadata for a single item."""
-    normalized_item_key = item_key.strip().upper()
-    if not normalized_item_key:
+def get_item(item_key: str = "", item_keys: list[str] | None = None) -> str:
+    """Full metadata for one item or a batch of items."""
+    requested_keys = _normalize_item_keys(item_key=item_key, item_keys=item_keys)
+    if not requested_keys:
+        if item_keys is not None:
+            return json.dumps({
+                "error": "Provide item_key or item_keys",
+                "items": [],
+                "total": 0,
+            })
+
         payload = _empty_item_payload()
         payload["error"] = "Provide item_key"
         return json.dumps(payload)
 
-    try:
-        zot = _get_zot()
-        item = zot.item(normalized_item_key)
-    except Exception as exc:
-        payload = _empty_item_payload(normalized_item_key)
-        payload["error"] = f"Failed to fetch item {normalized_item_key}: {exc}"
-        return json.dumps(payload)
+    attachments_by_parent = _get_item_attachments_by_parent(requested_keys)
 
-    return json.dumps(
-        _item_to_dict(
-            item,
-            truncate_abstract=0,
-            include_attachments=True,
-            max_creators=_DETAIL_VIEW_MAX_CREATORS,
+    if len(requested_keys) == 1:
+        normalized_item_key = requested_keys[0]
+        try:
+            item = _fetch_item_detail(normalized_item_key)
+        except Exception as exc:
+            payload = _empty_item_payload(normalized_item_key)
+            payload["error"] = f"Failed to fetch item {normalized_item_key}: {exc}"
+            return json.dumps(payload)
+
+        return json.dumps(
+            _item_to_dict(
+                item,
+                truncate_abstract=0,
+                include_attachments=True,
+                max_creators=_DETAIL_VIEW_MAX_CREATORS,
+                attachments=attachments_by_parent.get(normalized_item_key, []),
+            )
         )
-    )
+
+    items: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    max_workers = min(_ITEM_DETAIL_MAX_WORKERS, len(requested_keys))
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [executor.submit(_fetch_item_detail, key) for key in requested_keys]
+        for key, future in zip(requested_keys, futures):
+            try:
+                item = future.result()
+            except Exception as exc:
+                errors.append({
+                    "key": key,
+                    "error": f"Failed to fetch item {key}: {exc}",
+                })
+                continue
+
+            items.append(
+                _item_to_dict(
+                    item,
+                    truncate_abstract=0,
+                    include_attachments=True,
+                    max_creators=_DETAIL_VIEW_MAX_CREATORS,
+                    attachments=attachments_by_parent.get(key, []),
+                )
+            )
+
+    payload: dict[str, Any] = {
+        "item_keys": requested_keys,
+        "items": items,
+        "requested": len(requested_keys),
+        "total": len(items),
+    }
+    if errors:
+        payload["errors"] = errors
+
+    return json.dumps(payload)
 
 
 def get_bibtex_and_citation_for_items(

--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -118,23 +118,29 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
 
 
 @mcp_server.tool()
-def get_item(item_key: str) -> str:
-    """Get full metadata for a single Zotero item.
+def get_item(item_key: str = "", item_keys: list[str] | None = None) -> str:
+    """Get full metadata for one Zotero item or a batch of items.
 
     Args:
-        item_key: The Zotero item key. Use the `key` field from
+        item_key: A single Zotero item key. Use the `key` field from
             `search_library`, `list_collection_items`, or `get_recent_items`
             results (for example, `X9KJ2M4P`).
+        item_keys: Optional additional Zotero item keys for batch detail
+            retrieval. `item_key` and `item_keys` can be combined, and at
+            least one must be provided for batch mode. Single-key requests
+            keep the legacy single-item response shape.
 
     Returns:
-        JSON with complete item metadata including the full untruncated
-        abstract, title, creators, date, DOI, URL, tags, collections,
-        attachment counts, and attachment filepaths. Very large creator lists
-        are summarized to keep the payload bounded. Search results already
-        include most fields, so use this only when the full abstract or full
+        Single-key requests return JSON with complete item metadata including
+        the full untruncated abstract, title, creators, date, DOI, URL, tags,
+        collections, attachment counts, and attachment filepaths. Multi-key
+        requests return JSON with `item_keys`, `items`, `requested`, `total`,
+        and optional per-item `errors`. Very large creator lists are
+        summarized to keep the payload bounded. Search results already include
+        most fields, so use this only when the full abstract or full
         attachment records are needed.
     """
-    return db.get_item(item_key)
+    return db.get_item(item_key=item_key, item_keys=item_keys)
 
 
 @mcp_server.tool()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -301,6 +301,31 @@ class AttachmentPathsTests(DbTestCase):
         self.assertEqual(result["attachments"], [])
         get_zot_mock.assert_not_called()
 
+    def test_get_item_supports_single_key_via_item_keys_without_changing_shape(self):
+        zot = Mock()
+        zot.item.return_value = self._paper_item()
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.get_item(item_keys=[" parent1 "]))
+
+        self.assertEqual(result["key"], "PARENT1")
+        self.assertNotIn("items", result)
+        zot.item.assert_called_once_with("PARENT1")
+
+    def test_get_item_requires_at_least_one_key_for_batch_mode(self):
+        with patch("zoty.db._get_zot") as get_zot_mock:
+            result = json.loads(db.get_item(item_keys=[]))
+
+        self.assertEqual(
+            result,
+            {
+                "error": "Provide item_key or item_keys",
+                "items": [],
+                "total": 0,
+            },
+        )
+        get_zot_mock.assert_not_called()
+
     def test_get_item_returns_structured_error_skeleton_for_fetch_failure(self):
         zot = Mock()
         zot.item.side_effect = RuntimeError("boom")
@@ -347,6 +372,62 @@ class AttachmentPathsTests(DbTestCase):
         self.assertEqual(len(created_clients), 1)
         self.assertTrue(all(result is not None for result in results))
         self.assertEqual({id(result) for result in results}, {id(created_clients[0])})
+
+    def test_get_item_returns_multiple_items_and_partial_errors(self):
+        zot = Mock()
+
+        def item_side_effect(item_key):
+            if item_key == "BADKEY":
+                raise RuntimeError("missing item")
+
+            item = self._paper_item()
+            item["data"]["key"] = item_key
+            item["data"]["title"] = f"{item_key} title"
+            item["data"]["abstractNote"] = f"{item_key} abstract"
+            return item
+
+        zot.item.side_effect = item_side_effect
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.get_item(item_keys=["parent1", "badkey", "parent2"]))
+
+        self.assertEqual(result["item_keys"], ["PARENT1", "BADKEY", "PARENT2"])
+        self.assertEqual(result["requested"], 3)
+        self.assertEqual(result["total"], 2)
+        self.assertEqual([item["key"] for item in result["items"]], ["PARENT1", "PARENT2"])
+        self.assertEqual(
+            result["errors"],
+            [
+                {
+                    "key": "BADKEY",
+                    "error": "Failed to fetch item BADKEY: missing item",
+                }
+            ],
+        )
+
+    def test_get_item_fetches_multiple_items_concurrently_and_batches_attachments(self):
+        barrier = threading.Barrier(2)
+
+        def fetch_side_effect(item_key):
+            barrier.wait(timeout=1)
+            item = self._paper_item()
+            item["data"]["key"] = item_key
+            return item
+
+        with (
+            patch("zoty.db._fetch_item_detail", side_effect=fetch_side_effect) as fetch_mock,
+            patch(
+                "zoty.db._get_item_attachments_by_parent",
+                return_value={"GOOD1": [], "GOOD2": []},
+            ) as attachments_mock,
+        ):
+            result = json.loads(db.get_item(item_keys=["good1", "good2"]))
+
+        self.assertEqual(result["total"], 2)
+        self.assertNotIn("errors", result)
+        self.assertEqual(fetch_mock.call_count, 2)
+        self.assertEqual(attachments_mock.call_count, 1)
+        attachments_mock.assert_called_once_with(["GOOD1", "GOOD2"])
 
     def test_list_collections_returns_structured_error_skeleton_for_fetch_failure(self):
         with patch("zoty.db._get_zot", side_effect=RuntimeError("boom")):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -153,6 +153,15 @@ class ServerToolTests(unittest.TestCase):
         self.assertIn("attachment_key", server.search_within_item.__doc__)
         self.assertIn("attachment_count", server.list_collection_items.__doc__)
         self.assertIn("attachment_count", server.get_recent_items.__doc__)
+        self.assertIn("Single-key requests return JSON", server.get_item.__doc__)
+        self.assertIn("`item_keys`, `items`, `requested`, `total`", server.get_item.__doc__)
+
+    def test_get_item_delegates_to_db(self):
+        with patch.object(server.db, "get_item", return_value='{"key": "ITEM123"}') as db_mock:
+            result = server.get_item(item_key="ITEM123", item_keys=["ITEM456"])
+
+        self.assertEqual(result, '{"key": "ITEM123"}')
+        db_mock.assert_called_once_with(item_key="ITEM123", item_keys=["ITEM456"])
 
     def test_get_bibtex_and_citation_for_items_delegates_to_db(self):
         with patch.object(server.db, "get_bibtex_and_citation_for_items", return_value='{"items": []}') as db_mock:
@@ -182,6 +191,21 @@ class ServerToolTests(unittest.TestCase):
         description = asyncio.run(get_tool_description())
 
         self.assertIn("Provide at least one of `item_key` or `item_keys`.", description)
+
+    def test_get_item_tool_description_mentions_batch_inputs_and_response_shape(self):
+        async def get_tool_description():
+            tools = await server.mcp_server.list_tools()
+            for tool in tools:
+                if tool.name == "get_item":
+                    return tool.description
+            self.fail("get_item tool was not registered")
+
+        description = asyncio.run(get_tool_description())
+        normalized_description = " ".join(description.split())
+
+        self.assertIn("`item_key` and `item_keys` can be combined", normalized_description)
+        self.assertIn("Single-key requests keep the legacy single-item response shape.", normalized_description)
+        self.assertIn("`item_keys`, `items`, `requested`, `total`", normalized_description)
 
     def test_add_paper_tool_description_mentions_required_inputs_and_precedence(self):
         async def get_tool_description():


### PR DESCRIPTION
## Summary
- extend `get_item` to accept optional `item_keys` while preserving the legacy single-item response shape for single-key requests
- batch attachment lookups and fetch multi-item details concurrently with per-item error reporting
- document the updated tool contract and add DB/server coverage for batch behavior

Closes #79