### PR TITLE
Fix get_item errors and compact citation exports

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -44,6 +44,7 @@ _LIST_VIEW_MAX_CREATORS = 5
 _CITATION_EXPORT_MAX_WORKERS = 4
 _ITEM_DETAIL_MAX_WORKERS = 4
 _DETAIL_VIEW_MAX_CREATORS = 15
+_BIBTEX_MAX_AUTHORS = 10
 _EMPTY_QUERY_WARNING = "Query produced no searchable terms after stop-word removal. Try more specific keywords."
 _LINK_MODE_LABELS = {
     0: "imported_file",
@@ -475,6 +476,13 @@ def _empty_item_summary(item_key: str = "") -> dict[str, str]:
     }
 
 
+def _error_payload(error: str, *, key: str = "") -> dict[str, str]:
+    payload = {"error": error}
+    if key:
+        payload["key"] = key
+    return payload
+
+
 def _normalize_item_keys(item_key: str = "", item_keys: list[str] | None = None) -> list[str]:
     """Normalize a single key and/or key list into a clean ordered list."""
     normalized: list[str] = []
@@ -565,9 +573,114 @@ def _strip_bibtex_field(bibtex: str, field_name: str) -> str:
     return "".join(output)
 
 
+def _truncate_bibtex_authors(bibtex: str, *, max_authors: int = _BIBTEX_MAX_AUTHORS) -> str:
+    if not bibtex or max_authors < 0:
+        return bibtex
+
+    pattern = re.compile(
+        r"(^[ \t]*author[ \t]*=[ \t]*\{)(.*?)(\}[ \t]*,?[ \t]*$)",
+        re.IGNORECASE | re.MULTILINE | re.DOTALL,
+    )
+
+    def replace(match: re.Match[str]) -> str:
+        authors = [
+            author.strip()
+            for author in re.sub(r"\s+", " ", match.group(2)).split(" and ")
+            if author.strip()
+        ]
+        if len(authors) <= max_authors:
+            return match.group(0)
+        truncated = " and ".join([*authors[:max_authors], "others"])
+        return f"{match.group(1)}{truncated}{match.group(3)}"
+
+    return pattern.sub(replace, bibtex, count=1)
+
+
 def _compact_bibtex_export(bibtex: str) -> str:
     """Drop fields that duplicate data already provided by other tools."""
-    return _strip_bibtex_field(bibtex, "abstract").strip()
+    compacted = _strip_bibtex_field(bibtex, "abstract")
+    compacted = _strip_bibtex_field(compacted, "file")
+    compacted = _truncate_bibtex_authors(compacted)
+    return compacted.strip()
+
+
+def _response_status_code(exc: Exception) -> int | None:
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if isinstance(status, int):
+        return status
+
+    match = re.search(r"\bCode:\s*(\d{3})\b", str(exc), re.IGNORECASE)
+    if match is not None:
+        return int(match.group(1))
+    return None
+
+
+def _response_url(exc: Exception) -> str:
+    response = getattr(exc, "response", None)
+    url = getattr(response, "url", "")
+    if isinstance(url, str) and url:
+        return url
+
+    match = re.search(r"\bURL:\s*(\S+)", str(exc), re.IGNORECASE)
+    if match is not None:
+        return match.group(1)
+    return ""
+
+
+def _response_body(exc: Exception) -> str:
+    match = re.search(r"\bResponse:\s*(.*)", str(exc), re.IGNORECASE | re.DOTALL)
+    if match is None:
+        return ""
+    return " ".join(match.group(1).split())
+
+
+def _sanitize_external_error_message(exc: Exception, *, fallback: str) -> str:
+    message = " ".join(str(exc).split())
+    if not message:
+        return fallback
+
+    sanitized = re.sub(r"https?://\S+", "", message)
+    sanitized = re.sub(r"^(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\b", "", sanitized, flags=re.IGNORECASE)
+    sanitized = re.sub(r"(?i)\b(?:method|code|response|body)\b[^.;]*", "", sanitized)
+    sanitized = re.sub(r"\s+", " ", sanitized).strip(" .,:;-")
+    if sanitized and sanitized.upper() not in {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}:
+        return sanitized
+
+    status = _response_status_code(exc)
+    if status is not None:
+        return f"request failed with status {status}"
+    return fallback
+
+
+def _item_fetch_error_message(item_key: str, exc: Exception) -> str:
+    status = _response_status_code(exc)
+    if status == 404 or "not found" in str(exc).lower():
+        return f"Item {item_key} was not found"
+    detail = _sanitize_external_error_message(exc, fallback="request failed")
+    return f"Failed to fetch item {item_key}: {detail}"
+
+
+def _citation_fetch_error_message(item_key: str, style: str, exc: Exception) -> str:
+    status = _response_status_code(exc)
+    url = _response_url(exc).lower()
+    lowered = str(exc).lower()
+    response_body = _response_body(exc).lower()
+
+    if status == 404 and (
+        "/styles/" in url
+        or "citationstyles.org" in url
+        or "/styles/" in lowered
+        or "citationstyles.org" in lowered
+        or "citation style" in response_body
+        or ("style" in response_body and "not found" in response_body)
+    ):
+        return f"Citation style {style} was not found"
+    if status == 404 or "not found" in lowered:
+        return f"Item {item_key} was not found"
+
+    detail = _sanitize_external_error_message(exc, fallback="request failed")
+    return f"Failed to fetch citation entry: {detail}"
 
 
 def _fetch_item_exports(
@@ -2308,9 +2421,7 @@ def get_item(item_key: str = "", item_keys: list[str] | None = None) -> str:
                 "total": 0,
             })
 
-        payload = _empty_item_payload()
-        payload["error"] = "Provide item_key"
-        return json.dumps(payload)
+        return json.dumps(_error_payload("Provide item_key"))
 
     attachments_by_parent = _get_item_attachments_by_parent(requested_keys)
 
@@ -2319,9 +2430,12 @@ def get_item(item_key: str = "", item_keys: list[str] | None = None) -> str:
         try:
             item = _fetch_item_detail(normalized_item_key)
         except Exception as exc:
-            payload = _empty_item_payload(normalized_item_key)
-            payload["error"] = f"Failed to fetch item {normalized_item_key}: {exc}"
-            return json.dumps(payload)
+            return json.dumps(
+                _error_payload(
+                    _item_fetch_error_message(normalized_item_key, exc),
+                    key=normalized_item_key,
+                )
+            )
 
         return json.dumps(
             _item_to_dict(
@@ -2345,7 +2459,7 @@ def get_item(item_key: str = "", item_keys: list[str] | None = None) -> str:
             except Exception as exc:
                 errors.append({
                     "key": key,
-                    "error": f"Failed to fetch item {key}: {exc}",
+                    "error": _item_fetch_error_message(key, exc),
                 })
                 continue
 
@@ -2405,7 +2519,7 @@ def get_bibtex_and_citation_for_items(
         except Exception as exc:
             errors.append({
                 "key": key,
-                "error": f"Failed to fetch citation entry: {exc}",
+                "error": _citation_fetch_error_message(key, style, exc),
             })
     else:
         max_workers = min(_CITATION_EXPORT_MAX_WORKERS, len(requested_keys))
@@ -2421,7 +2535,7 @@ def get_bibtex_and_citation_for_items(
                 except Exception as exc:
                     errors.append({
                         "key": key,
-                        "error": f"Failed to fetch citation entry: {exc}",
+                        "error": _citation_fetch_error_message(key, style, exc),
                     })
 
     payload: dict[str, Any] = {
@@ -2434,7 +2548,7 @@ def get_bibtex_and_citation_for_items(
     if errors:
         payload["errors"] = errors
         if not results:
-            payload["error"] = "Failed to fetch citation entries"
+            payload["error"] = errors[0]["error"] if len(errors) == 1 else "Failed to fetch citation entries"
 
     return json.dumps(payload)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -44,6 +44,18 @@ class FakeRetriever:
         )
 
 
+class FakeResponse:
+    def __init__(self, *, status_code: int, url: str):
+        self.status_code = status_code
+        self.url = url
+
+
+class FakeHttpError(Exception):
+    def __init__(self, message: str, *, status_code: int, url: str):
+        super().__init__(message)
+        self.response = FakeResponse(status_code=status_code, url=url)
+
+
 class DbTestCase(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -277,28 +289,14 @@ class AttachmentPathsTests(DbTestCase):
         with patch("zoty.db._get_zot") as get_zot_mock:
             result = json.loads(db.get_item(""))
 
-        self.assertEqual(result["error"], "Provide item_key")
-        self.assertEqual(result["key"], "")
-        self.assertEqual(result["itemType"], "")
-        self.assertEqual(result["creators"], [])
-        self.assertEqual(result["tags"], [])
-        self.assertEqual(result["collections"], [])
-        self.assertEqual(result["attachment_count"], 0)
-        self.assertEqual(result["attachments"], [])
+        self.assertEqual(result, {"error": "Provide item_key"})
         get_zot_mock.assert_not_called()
 
     def test_get_item_rejects_whitespace_only_item_key(self):
         with patch("zoty.db._get_zot") as get_zot_mock:
             result = json.loads(db.get_item("   "))
 
-        self.assertEqual(result["error"], "Provide item_key")
-        self.assertEqual(result["key"], "")
-        self.assertEqual(result["itemType"], "")
-        self.assertEqual(result["creators"], [])
-        self.assertEqual(result["tags"], [])
-        self.assertEqual(result["collections"], [])
-        self.assertEqual(result["attachment_count"], 0)
-        self.assertEqual(result["attachments"], [])
+        self.assertEqual(result, {"error": "Provide item_key"})
         get_zot_mock.assert_not_called()
 
     def test_get_item_supports_single_key_via_item_keys_without_changing_shape(self):
@@ -333,14 +331,54 @@ class AttachmentPathsTests(DbTestCase):
         with patch("zoty.db._get_zot", return_value=zot):
             result = json.loads(db.get_item("PARENT1"))
 
-        self.assertEqual(result["key"], "PARENT1")
-        self.assertEqual(result["itemType"], "")
-        self.assertEqual(result["creators"], [])
-        self.assertEqual(result["tags"], [])
-        self.assertEqual(result["collections"], [])
-        self.assertEqual(result["attachment_count"], 0)
-        self.assertEqual(result["attachments"], [])
-        self.assertIn("Failed to fetch item PARENT1: boom", result["error"])
+        self.assertEqual(
+            result,
+            {
+                "key": "PARENT1",
+                "error": "Failed to fetch item PARENT1: boom",
+            },
+        )
+
+    def test_get_item_sanitizes_http_not_found_errors(self):
+        zot = Mock()
+        zot.item.side_effect = FakeHttpError(
+            "GET http://localhost:23119/api/users/0/items/PARENT1 Code 404 Response: not found",
+            status_code=404,
+            url="http://localhost:23119/api/users/0/items/PARENT1",
+        )
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.get_item("PARENT1"))
+
+        self.assertEqual(
+            result,
+            {
+                "key": "PARENT1",
+                "error": "Item PARENT1 was not found",
+            },
+        )
+        self.assertNotIn("localhost", json.dumps(result))
+
+    def test_get_item_sanitizes_stringified_http_not_found_errors(self):
+        zot = Mock()
+        zot.item.side_effect = RuntimeError(
+            (
+                "Code: 404 URL: http://localhost:23119/api/users/0/items/PARENT1 "
+                "Method: GET Response:"
+            )
+        )
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.get_item("PARENT1"))
+
+        self.assertEqual(
+            result,
+            {
+                "key": "PARENT1",
+                "error": "Item PARENT1 was not found",
+            },
+        )
+        self.assertNotIn("localhost", json.dumps(result))
 
     def test_get_zot_creates_only_one_client_under_concurrent_first_access(self):
         barrier = threading.Barrier(8)
@@ -2040,6 +2078,9 @@ class CitationEntryTests(DbTestCase):
                     (
                         f"@article{{{item_key},\n"
                         "  title={Example},\n"
+                        "  author={Author 1 and Author 2 and Author 3 and Author 4 and Author 5 and "
+                        "Author 6 and Author 7 and Author 8 and Author 9 and Author 10 and Author 11},\n"
+                        f"  file={{PDF:{db._ZOTERO_STORAGE / item_key / 'paper.pdf'}:application/pdf}},\n"
                         "  abstract={Detailed summary with {nested} braces},\n"
                         "  year={2026}\n"
                         "}"
@@ -2069,7 +2110,14 @@ class CitationEntryTests(DbTestCase):
                     "key": "ITEM123",
                     "citation": "ITEM123 & cite",
                     "bibliography": "ITEM123 reference",
-                    "bibtex": "@article{ITEM123,\n  title={Example},\n  year={2026}\n}",
+                    "bibtex": (
+                        "@article{ITEM123,\n"
+                        "  title={Example},\n"
+                        "  author={Author 1 and Author 2 and Author 3 and Author 4 and Author 5 and "
+                        "Author 6 and Author 7 and Author 8 and Author 9 and Author 10 and others},\n"
+                        "  year={2026}\n"
+                        "}"
+                    ),
                 }
             ],
         )
@@ -2127,6 +2175,34 @@ class CitationEntryTests(DbTestCase):
         self.assertEqual(result["requested"], 3)
         self.assertEqual(result["total"], 2)
 
+    def test_get_bibtex_and_citation_for_items_sanitizes_invalid_style_errors(self):
+        zot = Mock()
+        zot.item.side_effect = FakeHttpError(
+            "GET https://www.zotero.org/styles/not-a-style 404 Client Error",
+            status_code=404,
+            url="https://www.zotero.org/styles/not-a-style",
+        )
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(
+                db.get_bibtex_and_citation_for_items(
+                    item_key="item123",
+                    style="not-a-style",
+                )
+            )
+
+        self.assertEqual(result["error"], "Citation style not-a-style was not found")
+        self.assertEqual(
+            result["errors"],
+            [
+                {
+                    "key": "ITEM123",
+                    "error": "Citation style not-a-style was not found",
+                }
+            ],
+        )
+        self.assertNotIn("zotero.org/styles", json.dumps(result))
+
     def test_get_bibtex_and_citation_for_items_makes_one_export_call_per_item(self):
         zot = Mock()
         zot.item.return_value = {
@@ -2181,6 +2257,115 @@ class CitationEntryTests(DbTestCase):
         self.assertNotIn("errors", result)
         for item in result["items"]:
             self.assertNotIn("abstract", item["bibtex"].lower())
+
+    def test_get_bibtex_and_citation_for_items_strips_file_field_and_truncates_long_author_lists(self):
+        authors = " and ".join(
+            f"Author{index} Example"
+            for index in range(1, db._BIBTEX_MAX_AUTHORS + 4)
+        )
+
+        with patch(
+            "zoty.db._fetch_item_exports",
+            return_value={
+                "citation": "<span>cite</span>",
+                "bibliography": "<div>ref</div>",
+                "bibtex": (
+                    "@article{ITEM123,\n"
+                    f"  author={{{authors}}},\n"
+                    "  title={Example},\n"
+                    "  abstract={Detailed summary},\n"
+                    "  file={PDF:/Users/eric/Zotero/storage/6QDRGPA5/paper.pdf:application/pdf},\n"
+                    "  year={2026}\n"
+                    "}"
+                ),
+            },
+        ):
+            result = json.loads(db.get_bibtex_and_citation_for_items(item_key="item123"))
+
+        bibtex = result["items"][0]["bibtex"]
+        self.assertNotIn("abstract", bibtex.lower())
+        self.assertNotIn("file =", bibtex.lower())
+        self.assertNotIn("/Users/eric/Zotero/storage", bibtex)
+        self.assertIn("Author1 Example", bibtex)
+        self.assertIn(f"Author{db._BIBTEX_MAX_AUTHORS} Example", bibtex)
+        self.assertNotIn(f"Author{db._BIBTEX_MAX_AUTHORS + 1} Example", bibtex)
+        self.assertIn("and others", bibtex)
+
+    def test_get_bibtex_and_citation_for_items_sanitizes_item_not_found_http_errors(self):
+        with patch(
+            "zoty.db._fetch_item_exports",
+            side_effect=FakeHttpError(
+                (
+                    "Code: 404 URL: "
+                    "http://localhost:23119/api/users/0/items/MISSING"
+                    "?format=json&include=bib,citation,bibtex&style=apa&locale=en-US "
+                    "Method: GET Response: not found"
+                ),
+                status_code=404,
+                url=(
+                    "http://localhost:23119/api/users/0/items/MISSING"
+                    "?format=json&include=bib,citation,bibtex&style=apa&locale=en-US"
+                ),
+            ),
+        ):
+            result = json.loads(
+                db.get_bibtex_and_citation_for_items(
+                    item_key="missing",
+                    style="apa",
+                    locale="en-US",
+                )
+            )
+
+        self.assertEqual(result["error"], "Item MISSING was not found")
+        self.assertEqual(
+            result["errors"],
+            [
+                {
+                    "key": "MISSING",
+                    "error": "Item MISSING was not found",
+                }
+            ],
+        )
+        self.assertNotIn("localhost", json.dumps(result))
+
+    def test_get_bibtex_and_citation_for_items_sanitizes_invalid_style_http_errors(self):
+        with patch(
+            "zoty.db._fetch_item_exports",
+            side_effect=FakeHttpError(
+                (
+                    "Code: 404 URL: "
+                    "http://localhost:23119/api/users/0/items/ITEM123"
+                    "?format=json&include=bib,citation,bibtex&style=bad-style&locale=en-US "
+                    "Method: GET Response: Citation style not found: "
+                    "https://www.zotero.org/styles/bad-style"
+                ),
+                status_code=404,
+                url=(
+                    "http://localhost:23119/api/users/0/items/ITEM123"
+                    "?format=json&include=bib,citation,bibtex&style=bad-style&locale=en-US"
+                ),
+            ),
+        ):
+            result = json.loads(
+                db.get_bibtex_and_citation_for_items(
+                    item_key="item123",
+                    style="bad-style",
+                    locale="en-US",
+                )
+            )
+
+        self.assertEqual(result["error"], "Citation style bad-style was not found")
+        self.assertEqual(
+            result["errors"],
+            [
+                {
+                    "key": "ITEM123",
+                    "error": "Citation style bad-style was not found",
+                }
+            ],
+        )
+        self.assertNotIn("localhost", json.dumps(result))
+        self.assertNotIn("zotero.org/styles", json.dumps(result))
 
     def test_get_bibtex_and_citation_for_items_requires_at_least_one_key(self):
         result = json.loads(db.get_bibtex_and_citation_for_items())


### PR DESCRIPTION
## Summary
- return clean single-item error payloads instead of empty metadata skeletons
- strip BibTeX file fields, cap long author lists with `and others`, and keep exports bounded
- sanitize noisy Zotero HTTP errors so item/style failures stay concise and do not leak internal URLs

## Testing
- uv run --with pytest pytest

Fixes #104
Fixes #105
Fixes #106
Fixes #111