### PR TITLE
Fix limit semantics and recent item metadata

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -40,7 +40,7 @@ _CHUNK_WORDS = 200
 _CHUNK_OVERLAP_WORDS = 40
 _SEARCH_RESULT_LIMIT_CAP = 25
 _SEARCH_WITHIN_RESULT_LIMIT_CAP = 25
-_LIST_RESULT_LIMIT_CAP = 100
+_LIST_RESULT_LIMIT_CAP = _SEARCH_RESULT_LIMIT_CAP
 _LIST_VIEW_MAX_CREATORS = 5
 _CITATION_EXPORT_MAX_WORKERS = 4
 _ITEM_DETAIL_MAX_WORKERS = 4
@@ -408,6 +408,7 @@ def _item_to_dict(
     *,
     include_attachment_count: bool = False,
     include_attachments: bool = False,
+    include_date_added: bool = False,
     max_creators: int = -1,
     attachments: list[dict[str, Any]] | None = None,
     attachment_count: int | None = None,
@@ -436,6 +437,9 @@ def _item_to_dict(
         "collections": collections,
         "abstract": abstract,
     }
+
+    if include_date_added:
+        result["date_added"] = data.get("dateAdded", "")
 
     if include_attachment_count:
         if attachment_count is None:
@@ -1879,7 +1883,7 @@ def _search_response(
 
 
 def _apply_limit_cap(limit: int, cap: int) -> tuple[int, int]:
-    requested_limit = max(1, limit)
+    requested_limit = max(0, limit)
     return requested_limit, min(requested_limit, cap)
 
 
@@ -2016,8 +2020,7 @@ def search(
     include_attachments: bool = False,
 ) -> str:
     """BM25 ranked search over titles, abstracts, and indexed attachment full text."""
-    requested_limit = max(1, limit)
-    applied_limit = min(requested_limit, _SEARCH_RESULT_LIMIT_CAP)
+    requested_limit, applied_limit = _apply_limit_cap(limit, _SEARCH_RESULT_LIMIT_CAP)
     normalized_collection_key = collection_key.strip().upper()
     normalized_item_type = item_type.strip().lower()
 
@@ -2086,6 +2089,14 @@ def search(
             requested_limit=requested_limit,
             applied_limit=applied_limit,
             warning=_EMPTY_QUERY_WARNING,
+        )
+
+    if applied_limit == 0:
+        return _search_response(
+            query,
+            [],
+            requested_limit=requested_limit,
+            applied_limit=applied_limit,
         )
 
     max_docs = len(state.corpus_docs)
@@ -2304,6 +2315,33 @@ def search_within_item(
             warning=_EMPTY_QUERY_WARNING,
         )
 
+    if applied_limit == 0:
+        warning = None
+        if missing_item_keys:
+            warning = (
+                "Some requested item keys were not found in the search index: "
+                + ", ".join(missing_item_keys)
+            )
+        if multi_item:
+            return _search_within_item_response(
+                query=query,
+                matches=[],
+                requested_limit=requested_limit,
+                applied_limit=applied_limit,
+                item_keys=found_item_keys,
+                items=_multi_item_summaries_from_matches(found_item_keys, state.parents, []),
+                missing_item_keys=missing_item_keys,
+                warning=warning,
+            )
+        return _search_within_item_response(
+            key=normalized_item_key,
+            query=query,
+            matches=[],
+            requested_limit=requested_limit,
+            applied_limit=applied_limit,
+            item=item_summary,
+        )
+
     attachments_by_parent = _get_item_attachments_by_parent(found_item_keys)
     attachments_lookup_by_parent = {
         parent_key: {attachment["key"]: attachment for attachment in attachments}
@@ -2409,7 +2447,7 @@ def list_collections() -> str:
     return json.dumps({"collections": result, "total": len(result)})
 
 
-def list_collection_items(collection_key: str, limit: int = 50) -> str:
+def list_collection_items(collection_key: str, limit: int = _LIST_RESULT_LIMIT_CAP) -> str:
     """Return items in a specific collection."""
     requested_limit, applied_limit = _apply_limit_cap(limit, _LIST_RESULT_LIMIT_CAP)
     normalized_collection_key = collection_key.strip().upper()
@@ -2438,6 +2476,14 @@ def list_collection_items(collection_key: str, limit: int = 50) -> str:
                 "total": 0,
                 **_limit_response_metadata(requested_limit, applied_limit, _LIST_RESULT_LIMIT_CAP),
                 "error": f"Collection {normalized_collection_key} was not found",
+            })
+        if applied_limit == 0:
+            return json.dumps({
+                "collection_key": normalized_collection_key,
+                "collection_found": True,
+                "items": [],
+                "total": 0,
+                **_limit_response_metadata(requested_limit, applied_limit, _LIST_RESULT_LIMIT_CAP),
             })
         items = zot.collection_items(normalized_collection_key, limit=applied_limit)
     except Exception as exc:
@@ -2626,6 +2672,12 @@ def get_bibtex_and_citation_for_items(
 def get_recent_items(limit: int = 10) -> str:
     """Recently added items, sorted by dateAdded descending."""
     requested_limit, applied_limit = _apply_limit_cap(limit, _LIST_RESULT_LIMIT_CAP)
+    if applied_limit == 0:
+        return json.dumps({
+            "items": [],
+            "total": 0,
+            **_limit_response_metadata(requested_limit, applied_limit, _LIST_RESULT_LIMIT_CAP),
+        })
     try:
         zot = _get_zot()
         items = zot.items(
@@ -2647,6 +2699,7 @@ def get_recent_items(limit: int = 10) -> str:
             item,
             truncate_abstract=500,
             include_attachment_count=True,
+            include_date_added=True,
             max_creators=_LIST_VIEW_MAX_CREATORS,
         )
         for item in items

--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -107,12 +107,12 @@ def list_collections() -> str:
 
 
 @mcp_server.tool()
-def list_collection_items(collection_key: str, limit: int = 50) -> str:
+def list_collection_items(collection_key: str, limit: int = db._LIST_RESULT_LIMIT_CAP) -> str:
     """List items in a specific Zotero collection.
 
     Args:
         collection_key: The Zotero collection key (from list_collections)
-        limit: Requested items to return before the cap is applied (default: 50)
+        limit: Requested items to return before the cap is applied (default: 25)
 
     Returns:
         JSON with `collection_key`, `collection_found`, `items`, and limit
@@ -192,8 +192,8 @@ def get_recent_items(limit: int = 10) -> str:
 
     Returns:
         JSON with `items`, `total`, and limit metadata. Each item includes
-        `key`, `title`, `creators`, `date`, truncated `abstract` (500 chars),
-        `attachment_count`, and other summary fields.
+        `key`, `title`, `creators`, `date`, `date_added`, truncated
+        `abstract` (500 chars), `attachment_count`, and other summary fields.
     """
     return db.get_recent_items(limit=limit)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -89,6 +89,7 @@ class DbTestCase(unittest.TestCase):
                 "title": "Example Paper",
                 "creators": [{"firstName": "Jane", "lastName": "Example"}],
                 "date": "2026-03-10",
+                "dateAdded": "2026-03-10 09:00:00",
                 "DOI": "10.1000/example",
                 "url": "https://example.org/paper",
                 "tags": [{"tag": "chemistry"}],
@@ -659,11 +660,30 @@ class CollectionItemTests(DbTestCase):
         self.assertFalse(result["collection_found"])
         self.assertEqual(result["items"], [])
         self.assertEqual(result["total"], 0)
-        self.assertEqual(result["requested_limit"], 50)
-        self.assertEqual(result["applied_limit"], 50)
+        self.assertEqual(result["requested_limit"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertEqual(result["applied_limit"], db._LIST_RESULT_LIMIT_CAP)
         self.assertEqual(result["limit_cap"], db._LIST_RESULT_LIMIT_CAP)
         self.assertFalse(result["limit_capped"])
         self.assertIn("not found", result["error"])
+        zot.collection_items.assert_not_called()
+
+    def test_list_collection_items_preserves_zero_limit_without_fetching_items(self):
+        zot = Mock()
+        zot.collections.return_value = [
+            {"data": {"key": "COLL123", "name": "Valid Collection"}}
+        ]
+
+        with patch("zoty.db._get_zot", return_value=zot):
+            result = json.loads(db.list_collection_items("coll123", limit=0))
+
+        self.assertEqual(result["collection_key"], "COLL123")
+        self.assertTrue(result["collection_found"])
+        self.assertEqual(result["items"], [])
+        self.assertEqual(result["total"], 0)
+        self.assertEqual(result["requested_limit"], 0)
+        self.assertEqual(result["applied_limit"], 0)
+        self.assertEqual(result["limit_cap"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
         zot.collection_items.assert_not_called()
 
     def test_list_collection_items_returns_structured_filtered_items_for_valid_key(self):
@@ -841,6 +861,19 @@ class RecentItemsTests(DbTestCase):
                 "... and 3 more",
             ],
         )
+        self.assertEqual(result["items"][0]["date_added"], "2026-03-10 09:00:00")
+
+    def test_get_recent_items_preserves_zero_limit_without_fetching_items(self):
+        with patch("zoty.db._get_zot") as get_zot_mock:
+            result = json.loads(db.get_recent_items(limit=0))
+
+        self.assertEqual(result["items"], [])
+        self.assertEqual(result["total"], 0)
+        self.assertEqual(result["requested_limit"], 0)
+        self.assertEqual(result["applied_limit"], 0)
+        self.assertEqual(result["limit_cap"], db._LIST_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
+        get_zot_mock.assert_not_called()
 
     def test_get_recent_items_caps_requested_limit_and_reports_metadata(self):
         zot = Mock()
@@ -1042,6 +1075,7 @@ class RecentItemsTests(DbTestCase):
                     "title": "Recent Paper",
                     "creators": [{"firstName": "Jane", "lastName": "Example"}],
                     "date": "2026-03-10",
+                    "dateAdded": "2026-03-10 10:05:00",
                     "DOI": "10.1000/recent",
                     "url": "https://example.org/recent",
                     "tags": [{"tag": "ml"}],
@@ -1075,6 +1109,7 @@ class RecentItemsTests(DbTestCase):
         self.assertFalse(result["limit_capped"])
         self.assertEqual(result["items"][0]["key"], "ITEM1")
         self.assertEqual(result["items"][0]["attachment_count"], 1)
+        self.assertEqual(result["items"][0]["date_added"], "2026-03-10 10:05:00")
         self.assertNotIn("attachments", result["items"][0])
         zot.items.assert_called_once_with(limit=3, sort="dateAdded", direction="desc")
 
@@ -1510,6 +1545,32 @@ class SearchBehaviorTests(DbTestCase):
         self.assertEqual([call["k"] for call in db._search_state.retriever.calls], [500])
         self.assertEqual(result["items"][0]["key"], "PARENT1")
 
+    def test_search_preserves_zero_limit_without_retrieval(self):
+        self._install_search_state([
+            ({
+                "doc_id": "meta:PARENT1",
+                "parent_key": "PARENT1",
+                "attachment_key": "",
+                "doc_kind": "metadata",
+                "chunk_index": 0,
+                "char_start": 0,
+                "char_end": 30,
+                "token_count": 4,
+                "text": "query match metadata",
+                "text_hash": "hash-1",
+            }, 7.0),
+        ])
+
+        result = json.loads(db.search("query", limit=0))
+
+        self.assertEqual(result["items"], [])
+        self.assertEqual(result["total"], 0)
+        self.assertEqual(result["requested_limit"], 0)
+        self.assertEqual(result["applied_limit"], 0)
+        self.assertEqual(result["limit_cap"], db._SEARCH_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
+        self.assertEqual(db._search_state.retriever.calls, [])
+
     def test_search_returns_warning_when_query_has_no_searchable_terms(self):
         self._install_search_state([
             ({
@@ -1683,6 +1744,29 @@ class SearchBehaviorTests(DbTestCase):
         self.assertEqual(result["limit_cap"], db._SEARCH_WITHIN_RESULT_LIMIT_CAP)
         self.assertFalse(result["limit_capped"])
         self.assertEqual(result["warning"], db._EMPTY_QUERY_WARNING)
+        self.assertEqual(db._search_state.retriever.calls, [])
+
+    def test_search_within_item_preserves_zero_limit_without_retrieval(self):
+        self._install_search_state([
+            ({
+                "doc_id": "meta:PARENT1",
+                "parent_key": "PARENT1",
+                "attachment_key": "",
+                "doc_kind": "metadata",
+                "chunk_index": 0,
+                "char_start": 0,
+                "char_end": 20,
+                "token_count": 3,
+                "text": "query match first",
+                "text_hash": "hash-1",
+            }, 7.0),
+        ])
+
+        result = json.loads(db.search_within_item("parent1", "query", limit=0))
+
+        self.assertEqual(result["item"], {"key": "PARENT1", "title": "Example Paper"})
+        self.assertEqual(result["matches"], [])
+        self.assertEqual(result["total"], 0)
         self.assertEqual(db._search_state.retriever.calls, [])
 
     def test_search_within_item_does_not_return_warning_for_valid_zero_match_query(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -85,6 +85,7 @@ class ServerToolTests(unittest.TestCase):
         self.assertIn("truncated `abstract` (500 chars)", list_doc)
         self.assertIn("Requested items to return before the cap is applied", recent_doc)
         self.assertIn("JSON with `items`, `total`, and limit metadata.", recent_doc)
+        self.assertIn("`date_added`", recent_doc)
         self.assertIn("truncated `abstract` (500 chars)", recent_doc)
 
     def test_search_library_delegates_to_db(self):


### PR DESCRIPTION
## Summary
- preserve zero limits across search, collection, recent, and search-within-item flows instead of coercing them to one
- lower the collection/recent cap to 25 and align the list tool default with that cap
- include `date_added` in recent item payloads and cover the contract with tests

Fixes #102
Fixes #103
Fixes #107