### PR TITLE
Cap search_within_item and summarize multi-item matches

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -1785,6 +1785,39 @@ def _item_summary_from_parent(parent: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _top_match_summary(match: dict[str, Any]) -> dict[str, Any]:
+    return {
+        field: value
+        for field, value in match.items()
+        if field != "key"
+    }
+
+
+def _items_with_match_breakdown(
+    items: list[dict[str, Any]],
+    matches: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    matches_by_key: dict[str, list[dict[str, Any]]] = {}
+    for match in matches:
+        match_key = str(match.get("key", "") or "")
+        if not match_key:
+            continue
+        matches_by_key.setdefault(match_key, []).append(match)
+
+    summarized_items: list[dict[str, Any]] = []
+    for item in items:
+        item_key = str(item.get("key", "") or "")
+        item_matches = matches_by_key.get(item_key, [])
+        summary = dict(item)
+        summary["match_count"] = len(item_matches)
+        if item_matches:
+            top_match = max(item_matches, key=lambda row: float(row.get("score", 0.0)))
+            summary["top_match"] = _top_match_summary(top_match)
+        summarized_items.append(summary)
+
+    return summarized_items
+
+
 def _result_from_doc(
     parent: dict[str, Any],
     *,
@@ -1820,6 +1853,8 @@ def _search_within_item_response(
     *,
     query: str,
     matches: list[dict[str, Any]],
+    requested_limit: int,
+    applied_limit: int,
     key: str | None = None,
     item: dict[str, Any] | None = None,
     item_keys: list[str] | None = None,
@@ -1832,10 +1867,11 @@ def _search_within_item_response(
         "matches": matches,
         "query": query,
         "total": len(matches),
+        **_limit_response_metadata(requested_limit, applied_limit, _SEARCH_RESULT_LIMIT_CAP),
     }
     if item_keys is not None:
         payload["item_keys"] = list(item_keys)
-        payload["items"] = items or []
+        payload["items"] = _items_with_match_breakdown(items or [], matches)
         if missing_item_keys:
             payload["missing_item_keys"] = list(missing_item_keys)
     else:
@@ -2013,7 +2049,7 @@ def search_within_item(
     item_keys: list[str] | None = None,
 ) -> str:
     """BM25 ranked passage search within one or more parent items."""
-    limit = max(1, limit)
+    requested_limit, applied_limit = _apply_limit_cap(limit, _SEARCH_RESULT_LIMIT_CAP)
     requested_keys = _normalize_item_keys(item_key=item_key, item_keys=item_keys)
     unique_requested_keys: list[str] = []
     for key in requested_keys:
@@ -2025,6 +2061,8 @@ def search_within_item(
             key="",
             query=query,
             matches=[],
+            requested_limit=requested_limit,
+            applied_limit=applied_limit,
             error="Provide item_key or item_keys",
         )
 
@@ -2039,6 +2077,8 @@ def search_within_item(
             return _search_within_item_response(
                 query=query,
                 matches=[],
+                requested_limit=requested_limit,
+                applied_limit=applied_limit,
                 item_keys=unique_requested_keys,
                 items=[],
                 error="Index is still building, please retry in a moment",
@@ -2047,6 +2087,8 @@ def search_within_item(
             key=normalized_item_key,
             query=query,
             matches=[],
+            requested_limit=requested_limit,
+            applied_limit=applied_limit,
             error="Index is still building, please retry in a moment",
         )
 
@@ -2058,6 +2100,8 @@ def search_within_item(
             return _search_within_item_response(
                 query=query,
                 matches=[],
+                requested_limit=requested_limit,
+                applied_limit=applied_limit,
                 item_keys=unique_requested_keys,
                 items=[],
                 missing_item_keys=missing_item_keys,
@@ -2067,6 +2111,8 @@ def search_within_item(
             key=normalized_item_key,
             query=query,
             matches=[],
+            requested_limit=requested_limit,
+            applied_limit=applied_limit,
             error=f"Item {normalized_item_key} was not found in the search index",
         )
 
@@ -2086,6 +2132,8 @@ def search_within_item(
             return _search_within_item_response(
                 query=query,
                 matches=[],
+                requested_limit=requested_limit,
+                applied_limit=applied_limit,
                 item_keys=found_item_keys,
                 items=items_summary,
                 missing_item_keys=missing_item_keys,
@@ -2095,6 +2143,8 @@ def search_within_item(
             key=normalized_item_key,
             query=query,
             matches=[],
+            requested_limit=requested_limit,
+            applied_limit=applied_limit,
             item=item_summary,
         )
 
@@ -2116,6 +2166,8 @@ def search_within_item(
             return _search_within_item_response(
                 query=query,
                 matches=[],
+                requested_limit=requested_limit,
+                applied_limit=applied_limit,
                 item_keys=found_item_keys,
                 items=items_summary,
                 missing_item_keys=missing_item_keys,
@@ -2125,6 +2177,8 @@ def search_within_item(
             key=normalized_item_key,
             query=query,
             matches=[],
+            requested_limit=requested_limit,
+            applied_limit=applied_limit,
             item=item_summary,
             warning=_EMPTY_QUERY_WARNING,
         )
@@ -2136,7 +2190,7 @@ def search_within_item(
     }
 
     max_docs = len(state.corpus_docs)
-    batch_size = min(max(limit * 20, 200), max_docs)
+    batch_size = min(max(applied_limit * 20, 200), max_docs)
     matches: list[dict[str, Any]] = []
     seen_doc_ids: set[str] = set()
     found_item_key_set = set(found_item_keys)
@@ -2171,7 +2225,7 @@ def search_within_item(
                 include_parent_key=multi_item,
             ))
 
-            if len(matches) >= limit:
+            if len(matches) >= applied_limit:
                 found_enough = True
                 break
 
@@ -2189,7 +2243,9 @@ def search_within_item(
             )
         return _search_within_item_response(
             query=query,
-            matches=matches[:limit],
+            matches=matches[:applied_limit],
+            requested_limit=requested_limit,
+            applied_limit=applied_limit,
             item_keys=found_item_keys,
             items=items_summary,
             missing_item_keys=missing_item_keys,
@@ -2199,7 +2255,9 @@ def search_within_item(
     return _search_within_item_response(
         key=normalized_item_key,
         query=query,
-        matches=matches[:limit],
+        matches=matches[:applied_limit],
+        requested_limit=requested_limit,
+        applied_limit=applied_limit,
         item=item_summary,
     )
 

--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -71,17 +71,19 @@ def search_within_item(
         item_keys: Optional additional Zotero parent item keys to search
             within together with item_key for cross-item ranking.
         query: Search keywords to match against that item's metadata and attachment chunks
-        limit: Maximum number of passage matches to return (default: 5)
+        limit: Requested passage matches to return before the cap is applied
+            (default: 5)
 
     Returns:
-        JSON with ranked passage `matches`, including `snippet`,
+        JSON with ranked passage `matches`, limit metadata, and `snippet`,
         `chunk_index`, `char_start`, and `char_end` for every hit. When a
         match comes from an attachment chunk, it also includes
         `attachment_key`, `attachment_title`, and `attachment_filepath` so you
         can identify the source file for that passage. Single-item calls
         return `key` and `item`; multi-item calls return `item_keys` and
-        `items`. Matches omit the redundant parent title and include parent
-        `key` only for multi-item calls.
+        `items`, where each item includes per-item `match_count` and optional
+        `top_match` to summarize relevance. Matches omit the redundant parent
+        title and include parent `key` only for multi-item calls.
     """
     return db.search_within_item(
         item_key=item_key,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1604,6 +1604,10 @@ class SearchBehaviorTests(DbTestCase):
         self.assertEqual(result["item"], {"key": "PARENT1", "title": "First Paper"})
         self.assertNotIn("abstract", result["item"])
         self.assertNotIn("attachments", result["item"])
+        self.assertEqual(result["requested_limit"], 3)
+        self.assertEqual(result["applied_limit"], 3)
+        self.assertEqual(result["limit_cap"], db._SEARCH_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
         self.assertEqual(result["total"], 3)
         self.assertEqual(
             [row["match_type"] for row in result["matches"]],
@@ -1636,6 +1640,10 @@ class SearchBehaviorTests(DbTestCase):
         self.assertEqual(result["item"], {"key": "PARENT1", "title": "Example Paper"})
         self.assertEqual(result["matches"], [])
         self.assertEqual(result["total"], 0)
+        self.assertEqual(result["requested_limit"], 3)
+        self.assertEqual(result["applied_limit"], 3)
+        self.assertEqual(result["limit_cap"], db._SEARCH_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
         self.assertEqual(result["warning"], db._EMPTY_QUERY_WARNING)
         self.assertEqual(db._search_state.retriever.calls, [])
 
@@ -1660,6 +1668,10 @@ class SearchBehaviorTests(DbTestCase):
         self.assertEqual(result["item"], {"key": "PARENT1", "title": "Example Paper"})
         self.assertEqual(result["matches"], [])
         self.assertEqual(result["total"], 0)
+        self.assertEqual(result["requested_limit"], 3)
+        self.assertEqual(result["applied_limit"], 3)
+        self.assertEqual(result["limit_cap"], db._SEARCH_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
         self.assertNotIn("warning", result)
 
     def test_search_within_item_returns_error_for_unknown_item(self):
@@ -1683,6 +1695,10 @@ class SearchBehaviorTests(DbTestCase):
         self.assertEqual(result["key"], "MISSING")
         self.assertEqual(result["item"], {"key": "MISSING", "title": ""})
         self.assertEqual(result["matches"], [])
+        self.assertEqual(result["requested_limit"], 5)
+        self.assertEqual(result["applied_limit"], 5)
+        self.assertEqual(result["limit_cap"], db._SEARCH_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
         self.assertIn("was not found", result["error"])
 
     def test_search_within_item_supports_multi_item_queries(self):
@@ -1710,6 +1726,19 @@ class SearchBehaviorTests(DbTestCase):
                 "collections": ["COLL123"],
                 "tags": [],
                 "date": "2026-03-11",
+                "DOI": "",
+                "url": "",
+            },
+            "PARENT3": {
+                "key": "PARENT3",
+                "dateModified": "2026-03-12 10:00:00",
+                "itemType": "preprint",
+                "title": "Third Paper",
+                "abstract": "Third abstract.",
+                "creators": ["Jamie Example"],
+                "collections": ["COLL123"],
+                "tags": [],
+                "date": "2026-03-12",
                 "DOI": "",
                 "url": "",
             },
@@ -1745,24 +1774,86 @@ class SearchBehaviorTests(DbTestCase):
         result = json.loads(
             db.search_within_item(
                 item_key="parent1",
-                item_keys=["parent2"],
+                item_keys=["parent2", "parent3"],
                 query="query",
                 limit=2,
             )
         )
 
-        self.assertEqual(result["item_keys"], ["PARENT1", "PARENT2"])
-        self.assertEqual(
-            result["items"],
-            [
-                {"key": "PARENT1", "title": "First Paper"},
-                {"key": "PARENT2", "title": "Second Paper"},
-            ],
-        )
+        self.assertEqual(result["item_keys"], ["PARENT1", "PARENT2", "PARENT3"])
+        self.assertEqual(result["requested_limit"], 2)
+        self.assertEqual(result["applied_limit"], 2)
+        self.assertEqual(result["limit_cap"], db._SEARCH_RESULT_LIMIT_CAP)
+        self.assertFalse(result["limit_capped"])
         self.assertEqual(result["total"], 2)
         self.assertEqual([row["key"] for row in result["matches"]], ["PARENT2", "PARENT1"])
         self.assertNotIn("title", result["matches"][0])
         self.assertNotIn("title", result["matches"][1])
+        self.assertEqual(result["items"][0]["key"], "PARENT1")
+        self.assertEqual(result["items"][0]["title"], "First Paper")
+        self.assertEqual(result["items"][0]["match_count"], 1)
+        self.assertEqual(result["items"][0]["top_match"]["score"], 7.0)
+        self.assertEqual(result["items"][0]["top_match"]["match_type"], "metadata")
+        self.assertNotIn("key", result["items"][0]["top_match"])
+        self.assertEqual(result["items"][1]["key"], "PARENT2")
+        self.assertEqual(result["items"][1]["title"], "Second Paper")
+        self.assertEqual(result["items"][1]["match_count"], 1)
+        self.assertEqual(result["items"][1]["top_match"]["score"], 8.0)
+        self.assertEqual(result["items"][1]["top_match"]["match_type"], "metadata")
+        self.assertEqual(
+            result["items"][2],
+            {"key": "PARENT3", "title": "Third Paper", "match_count": 0},
+        )
+
+    def test_search_within_item_caps_requested_limit_and_retrieval_batch(self):
+        parents = {
+            "PARENT1": {
+                "key": "PARENT1",
+                "dateModified": "2026-03-10 10:00:00",
+                "itemType": "preprint",
+                "title": "First Paper",
+                "abstract": "First abstract.",
+                "creators": ["Jane Example"],
+                "collections": ["COLL123"],
+                "tags": [],
+                "date": "2026-03-10",
+                "DOI": "",
+                "url": "",
+            },
+        }
+        docs = [
+            ({
+                "doc_id": f"meta:PARENT1:{index}",
+                "parent_key": "PARENT1",
+                "attachment_key": "",
+                "doc_kind": "metadata",
+                "chunk_index": index,
+                "char_start": index * 10,
+                "char_end": (index * 10) + 20,
+                "token_count": 3,
+                "text": f"query match {index}",
+                "text_hash": f"hash-{index}",
+            }, float(1000 - index))
+            for index in range(600)
+        ]
+        self._install_search_state(docs, parents=parents)
+
+        result = json.loads(db.search_within_item("parent1", "query", limit=999))
+
+        self.assertEqual(result["requested_limit"], 999)
+        self.assertEqual(result["applied_limit"], db._SEARCH_RESULT_LIMIT_CAP)
+        self.assertEqual(result["limit_cap"], db._SEARCH_RESULT_LIMIT_CAP)
+        self.assertTrue(result["limit_capped"])
+        self.assertEqual(result["total"], db._SEARCH_RESULT_LIMIT_CAP)
+        self.assertEqual(len(result["matches"]), db._SEARCH_RESULT_LIMIT_CAP)
+        self.assertEqual(db._search_state.retriever.calls, [
+            {
+                "query_tokens": [["query"]],
+                "corpus": db._search_state.corpus_docs,
+                "k": db._SEARCH_RESULT_LIMIT_CAP * 20,
+                "show_progress": False,
+            }
+        ])
 
 
 class SnapshotLifecycleTests(DbTestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -146,12 +146,18 @@ class ServerToolTests(unittest.TestCase):
         self.assertIn("chunk_index", description)
         self.assertIn("char_start", description)
         self.assertIn("char_end", description)
+        self.assertIn("match_count", description)
+        self.assertIn("top_match", description)
+        self.assertIn("limit metadata", description)
 
     def test_response_shape_docstrings_reflect_canonical_keys(self):
         search_within_doc = " ".join(server.search_within_item.__doc__.split())
         self.assertIn("under `items`", server.search_library.__doc__)
         self.assertIn("`matches`", server.search_within_item.__doc__)
         self.assertIn("attachment_key", server.search_within_item.__doc__)
+        self.assertIn("limit metadata", server.search_within_item.__doc__)
+        self.assertIn("match_count", server.search_within_item.__doc__)
+        self.assertIn("top_match", server.search_within_item.__doc__)
         self.assertIn("include parent `key` only for multi-item calls", search_within_doc)
         self.assertIn("attachment_count", server.list_collection_items.__doc__)
         self.assertIn("attachment_count", server.get_recent_items.__doc__)


### PR DESCRIPTION
## Summary
- cap `search_within_item` responses with the shared search limit metadata
- add per-item `match_count` and `top_match` summaries for multi-item searches
- cover the new response shape and tool description in tests

Fixes #112
Fixes #113