### PR TITLE
Tighten search_within_item payloads and attachment metadata

### DIFF
--- a/src/zoty/db.py
+++ b/src/zoty/db.py
@@ -343,7 +343,7 @@ def _log_attachment_helper_error(message: str, exc: Exception) -> None:
 
 
 def _get_item_attachments_by_parent(item_keys: list[str]) -> dict[str, list[dict[str, Any]]]:
-    """Return attachment metadata for each requested parent item key."""
+    """Return privacy-safe attachment metadata for each requested parent item key."""
     normalized_keys: list[str] = []
     for item_key in item_keys:
         cleaned = item_key.strip().upper()
@@ -363,8 +363,7 @@ def _get_item_attachments_by_parent(item_keys: list[str]) -> dict[str, list[dict
                            child.key AS attachment_key,
                            COALESCE(MAX(CASE WHEN f.fieldName = 'title' THEN idv.value END), '') AS attachment_title,
                            ia.contentType AS content_type,
-                           ia.linkMode AS link_mode,
-                           ia.path AS raw_path
+                           ia.linkMode AS link_mode
                     FROM items parent
                     JOIN itemAttachments ia ON parent.itemID = ia.parentItemID
                     JOIN items child ON ia.itemID = child.itemID
@@ -372,7 +371,7 @@ def _get_item_attachments_by_parent(item_keys: list[str]) -> dict[str, list[dict
                     LEFT JOIN itemDataValues idv ON id.valueID = idv.valueID
                     LEFT JOIN fields f ON id.fieldID = f.fieldID
                     WHERE parent.key IN ({placeholders})
-                    GROUP BY parent.key, child.key, ia.contentType, ia.linkMode, ia.path, child.dateAdded
+                    GROUP BY parent.key, child.key, ia.contentType, ia.linkMode, child.dateAdded
                     ORDER BY parent.key ASC, child.dateAdded ASC""",
                 normalized_keys,
             ).fetchall()
@@ -386,22 +385,18 @@ def _get_item_attachments_by_parent(item_keys: list[str]) -> dict[str, list[dict
     for row in rows:
         parent_key = str(row["parent_key"])
         attachment_key = str(row["attachment_key"])
-        filepath = _resolve_attachment_filepath(attachment_key, row["raw_path"] or "")
-        if not filepath:
-            continue
         attachments_by_parent.setdefault(parent_key, []).append({
             "key": attachment_key,
             "title": row["attachment_title"],
             "contentType": row["content_type"] or "",
             "linkMode": _format_link_mode(row["link_mode"]),
-            "filepath": filepath,
         })
 
     return attachments_by_parent
 
 
 def _get_item_attachments(item_key: str) -> list[dict[str, Any]]:
-    """Return attachment metadata and resolved filepaths for one parent item."""
+    """Return privacy-safe attachment metadata for one parent item."""
     key = item_key.strip().upper()
     if not key:
         return []
@@ -547,6 +542,7 @@ def _empty_item_summary(item_key: str = "") -> dict[str, str]:
     return {
         "key": item_key,
         "title": "",
+        "itemType": "",
     }
 
 
@@ -2005,6 +2001,7 @@ def _item_summary_from_parent(parent: dict[str, Any]) -> dict[str, Any]:
     return {
         "key": parent["key"],
         "title": parent["title"],
+        "itemType": parent["itemType"],
     }
 
 
@@ -2099,7 +2096,6 @@ def _result_from_doc(
 ) -> dict[str, Any]:
     snippet_source = doc["text"] if doc["doc_kind"] == "attachment_chunk" else (parent["abstract"] or doc["text"])
     result = {
-        "itemType": parent["itemType"],
         "score": round(score, 4),
         "match_type": doc["doc_kind"],
         "snippet": _snippet_from_text(snippet_source, query_terms),
@@ -2114,7 +2110,6 @@ def _result_from_doc(
         attachment = attachments_by_key.get(doc["attachment_key"], {})
         result["attachment_key"] = doc["attachment_key"]
         result["attachment_title"] = attachment.get("title", "")
-        result["attachment_filepath"] = attachment.get("filepath", "")
 
     return result
 
@@ -2349,7 +2344,11 @@ def search_within_item(
     limit: int = 5,
     item_keys: list[str] | None = None,
 ) -> str:
-    """BM25 ranked passage search within one or more parent items."""
+    """BM25 ranked passage search within one or more parent items.
+
+    The public caller should prefer `item_keys`; `item_key` remains a narrow
+    compatibility shim for older internal callers.
+    """
     requested_limit, applied_limit = _apply_limit_cap(limit, _SEARCH_WITHIN_RESULT_LIMIT_CAP)
     requested_keys = _normalize_item_keys(item_key=item_key, item_keys=item_keys)
     unique_requested_keys: list[str] = []
@@ -2364,7 +2363,7 @@ def search_within_item(
             matches=[],
             requested_limit=requested_limit,
             applied_limit=applied_limit,
-            error="Provide item_key or item_keys",
+            error="Provide item_keys",
         )
 
     multi_item = len(unique_requested_keys) > 1

--- a/src/zoty/server.py
+++ b/src/zoty/server.py
@@ -91,10 +91,12 @@ def search_library(
     Returns:
         JSON with ranked Zotero items under `items`, including key, title,
         creators, date, score, abstract text truncated to 500 characters,
-        `attachment_count`, `collections` as `{key, name}` pairs, optional `attachments` when
-        `include_attachments=True`, optional plain-text snippets, warnings for
-        invalid `collection_key` / `item_type` filters or empty queries, and
-        limit metadata. Duplicate parent items that share a DOI or URL are
+        `attachment_count`, `collections` as `{key, name}` pairs, optional
+        `attachments` when `include_attachments=True` (each attachment keeps
+        only safe summary fields such as key, title, contentType, and
+        linkMode), optional plain-text snippets, warnings for invalid
+        `collection_key` / `item_type` filters or empty queries, and limit
+        metadata. Duplicate parent items that share a DOI or URL are
         collapsed before limiting, preferring the richer record when
         duplicates exist. `total` reports the deduplicated match count and
         `returned_count` reports how many items were actually returned.
@@ -110,42 +112,40 @@ def search_library(
 
 @mcp_server.tool()
 def search_within_item(
-    item_key: str,
+    item_keys: list[str],
     query: str,
     limit: int = 5,
-    item_keys: list[str] | None = None,
 ) -> str:
     """Find which passages within one or more known items match a keyword query.
 
     Use after `search_library` to drill into one paper, or compare passage-level
-    relevance across several papers in a single call.
+    relevance across several papers in a single call. The public interface uses
+    `item_keys` as the canonical key input.
 
     Args:
-        item_key: Zotero parent item key to search within. Use the `key`
+        item_keys: Zotero parent item keys to search within. Use the `key`
             field from `search_library`, `list_collection_items`, or
             `get_recent_items` results (for example, `X9KJ2M4P`).
-        item_keys: Optional additional Zotero parent item keys to search
-            within together with item_key for cross-item ranking.
-        query: Search keywords to match against that item's metadata and attachment chunks
+        query: Search keywords to match against those items' metadata and attachment chunks
         limit: Requested passage matches to return (default: 5, capped at
             25). The response includes `requested_limit`, `applied_limit`,
             `limit_cap`, and `limit_capped` so callers can detect clamping.
 
     Returns:
-        JSON with ranked passage `matches`, including `snippet`,
-        `chunk_index`, `char_start`, and `char_end` for every hit. When a
-        match comes from an attachment chunk, it also includes
-        `attachment_key`, `attachment_title`, and `attachment_filepath` so you
-        can identify the source file for that passage. Single-item calls
-        return `key` and `item`; multi-item calls return `item_keys` and
-        `items`, where each item summary also includes
-        `returned_match_count`, `top_score`, and `top_match_type` so agents
-        can compare relevance across the requested items without extra calls.
-        Matches omit the redundant parent title and include parent `key` only
-        for multi-item calls.
+        JSON with ranked passage `matches`, including `score`,
+        `match_type`, `snippet`, `chunk_index`, `char_start`, and
+        `char_end` for every hit. When a match comes from an attachment
+        chunk, it also includes `attachment_key` and `attachment_title` so
+        you can identify the source attachment without leaking local file
+        paths. Single-item calls return `key` and `item`; multi-item calls
+        return `item_keys` and `items`, where each item summary includes
+        `key`, `title`, `itemType`, `returned_match_count`, `top_score`, and
+        `top_match_type` so agents can compare relevance across the requested
+        items without extra calls. Matches omit the redundant parent title
+        and itemType, and include parent `key` only for multi-item calls.
     """
     return db.search_within_item(
-        item_key=item_key,
+        item_key="",
         item_keys=item_keys,
         query=query,
         limit=limit,
@@ -202,8 +202,9 @@ def get_item(item_key: str = "", item_keys: list[str] | None = None) -> str:
     Returns:
         Single-key requests return JSON with complete item metadata including
         the full untruncated abstract, title, creators, date, DOI, URL, tags,
-        collections as `{key, name}` pairs, attachment counts, and attachment
-        filepaths. Multi-key requests return JSON with `item_keys`, `items`,
+        collections as `{key, name}` pairs, attachment counts, and
+        privacy-safe attachment metadata that omits local file paths.
+        Multi-key requests return JSON with `item_keys`, `items`,
         `requested`, `total`, and optional per-item `errors`. Duplicate keys
         across `item_key` and `item_keys` are deduplicated before fetching.
         Very large creator lists are summarized more aggressively in batch

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -211,7 +211,7 @@ class AttachmentPathsTests(DbTestCase):
             )
             conn.commit()
 
-    def test_get_item_attachments_resolves_storage_filepaths(self):
+    def test_get_item_attachments_returns_slim_metadata_without_filepaths(self):
         attachments = db._get_item_attachments("PARENT1")
 
         self.assertEqual(
@@ -222,7 +222,6 @@ class AttachmentPathsTests(DbTestCase):
                     "title": "Attached PDF",
                     "contentType": "application/pdf",
                     "linkMode": "imported_file",
-                    "filepath": str(db._ZOTERO_STORAGE / "ATTACH1" / "paper.pdf"),
                 }
             ],
         )
@@ -271,7 +270,7 @@ class AttachmentPathsTests(DbTestCase):
         self.assertEqual(db._format_link_mode(99), "unknown(99)")
         self.assertEqual(db._format_link_mode(None), "unknown")
 
-    def test_get_item_includes_attachment_filepaths(self):
+    def test_get_item_includes_slim_attachment_metadata(self):
         zot = Mock()
         zot.item.return_value = self._paper_item()
 
@@ -280,12 +279,21 @@ class AttachmentPathsTests(DbTestCase):
 
         self.assertEqual(result["key"], "PARENT1")
         self.assertEqual(result["attachment_count"], 1)
-        self.assertEqual(result["attachments"][0]["filepath"], str(db._ZOTERO_STORAGE / "ATTACH1" / "paper.pdf"))
+        self.assertEqual(
+            result["attachments"][0],
+            {
+                "key": "ATTACH1",
+                "title": "Attached PDF",
+                "contentType": "application/pdf",
+                "linkMode": "imported_file",
+            },
+        )
         self.assertEqual(result["attachments"][0]["contentType"], "application/pdf")
         self.assertEqual(
             result["collections"],
             [{"key": "COLL123", "name": "Valid Collection"}],
         )
+        self.assertNotIn(str(db._ZOTERO_STORAGE), json.dumps(result))
 
     def test_get_item_normalizes_item_key_to_uppercase(self):
         zot = Mock()
@@ -636,13 +644,25 @@ class AttachmentPathsTests(DbTestCase):
         self.assertEqual([row["key"] for row in result["items"]], ["PARENT1", "PARENT2"])
         self.assertEqual([row["attachment_count"] for row in result["items"]], [1, 1])
         self.assertEqual(
-            result["items"][0]["attachments"][0]["filepath"],
-            str(db._ZOTERO_STORAGE / "ATTACH1" / "paper.pdf"),
+            result["items"][0]["attachments"][0],
+            {
+                "key": "ATTACH1",
+                "title": "Attached PDF",
+                "contentType": "application/pdf",
+                "linkMode": "imported_file",
+            },
         )
         self.assertEqual(
-            result["items"][1]["attachments"][0]["filepath"],
-            str(db._ZOTERO_STORAGE / "ATTACH2" / "book.epub"),
+            result["items"][1]["attachments"][0],
+            {
+                "key": "ATTACH2",
+                "title": "Attached EPUB",
+                "contentType": "application/epub+zip",
+                "linkMode": "imported_url",
+            },
         )
+        self.assertEqual(open_db_mock.call_count, 2)
+        self.assertNotIn(str(db._ZOTERO_STORAGE), json.dumps(result))
         self.assertEqual(open_db_mock.call_count, 2)
 
 
@@ -1953,7 +1973,10 @@ class SearchBehaviorTests(DbTestCase):
         result = json.loads(db.search_within_item("parent1", "query", limit=3))
 
         self.assertEqual(result["key"], "PARENT1")
-        self.assertEqual(result["item"], {"key": "PARENT1", "title": "First Paper"})
+        self.assertEqual(
+            result["item"],
+            {"key": "PARENT1", "title": "First Paper", "itemType": "preprint"},
+        )
         self.assertNotIn("abstract", result["item"])
         self.assertNotIn("attachments", result["item"])
         self.assertEqual(result["requested_limit"], 3)
@@ -1965,11 +1988,14 @@ class SearchBehaviorTests(DbTestCase):
             [row["match_type"] for row in result["matches"]],
             ["attachment_chunk", "attachment_chunk", "metadata"],
         )
+        self.assertEqual([row["score"] for row in result["matches"]], [9.0, 8.5, 7.5])
         self.assertNotIn("key", result["matches"][0])
         self.assertNotIn("title", result["matches"][0])
+        self.assertNotIn("itemType", result["matches"][0])
         self.assertEqual(result["matches"][0]["attachment_key"], "ATTACH1")
         self.assertEqual(result["matches"][1]["attachment_key"], "ATTACH2")
         self.assertNotIn("attachment_key", result["matches"][2])
+        self.assertNotIn("attachment_filepath", result["matches"][0])
 
     def test_search_within_item_returns_no_matches_when_limit_is_zero(self):
         self._install_search_state([
@@ -1989,7 +2015,10 @@ class SearchBehaviorTests(DbTestCase):
 
         result = json.loads(db.search_within_item("parent1", "query", limit=0))
 
-        self.assertEqual(result["item"], {"key": "PARENT1", "title": "Example Paper"})
+        self.assertEqual(
+            result["item"],
+            {"key": "PARENT1", "title": "Example Paper", "itemType": "preprint"},
+        )
         self.assertEqual(result["matches"], [])
         self.assertEqual(result["total"], 0)
         self.assertEqual(db._search_state.retriever.calls, [])
@@ -2012,7 +2041,10 @@ class SearchBehaviorTests(DbTestCase):
 
         result = json.loads(db.search_within_item("parent1", "the and", limit=0))
 
-        self.assertEqual(result["item"], {"key": "PARENT1", "title": "Example Paper"})
+        self.assertEqual(
+            result["item"],
+            {"key": "PARENT1", "title": "Example Paper", "itemType": "preprint"},
+        )
         self.assertEqual(result["matches"], [])
         self.assertEqual(result["total"], 0)
         self.assertEqual(result["warning"], db._EMPTY_QUERY_WARNING)
@@ -2036,7 +2068,10 @@ class SearchBehaviorTests(DbTestCase):
 
         result = json.loads(db.search_within_item("parent1", "the and", limit=3))
 
-        self.assertEqual(result["item"], {"key": "PARENT1", "title": "Example Paper"})
+        self.assertEqual(
+            result["item"],
+            {"key": "PARENT1", "title": "Example Paper", "itemType": "preprint"},
+        )
         self.assertEqual(result["matches"], [])
         self.assertEqual(result["total"], 0)
         self.assertEqual(result["requested_limit"], 3)
@@ -2064,7 +2099,10 @@ class SearchBehaviorTests(DbTestCase):
 
         result = json.loads(db.search_within_item("parent1", "quantum topology", limit=3))
 
-        self.assertEqual(result["item"], {"key": "PARENT1", "title": "Example Paper"})
+        self.assertEqual(
+            result["item"],
+            {"key": "PARENT1", "title": "Example Paper", "itemType": "preprint"},
+        )
         self.assertEqual(result["matches"], [])
         self.assertEqual(result["total"], 0)
         self.assertEqual(result["requested_limit"], 3)
@@ -2092,7 +2130,7 @@ class SearchBehaviorTests(DbTestCase):
         result = json.loads(db.search_within_item("missing", "query"))
 
         self.assertEqual(result["key"], "MISSING")
-        self.assertEqual(result["item"], {"key": "MISSING", "title": ""})
+        self.assertEqual(result["item"], {"key": "MISSING", "title": "", "itemType": ""})
         self.assertEqual(result["matches"], [])
         self.assertEqual(result["requested_limit"], 5)
         self.assertEqual(result["applied_limit"], 5)
@@ -2184,8 +2222,8 @@ class SearchBehaviorTests(DbTestCase):
 
         result = json.loads(
             db.search_within_item(
-                item_key="parent1",
-                item_keys=["parent2", "parent3"],
+                item_key="",
+                item_keys=["parent1", "parent2", "parent3"],
                 query="query",
                 limit=3,
             )
@@ -2198,6 +2236,7 @@ class SearchBehaviorTests(DbTestCase):
                 {
                     "key": "PARENT1",
                     "title": "First Paper",
+                    "itemType": "preprint",
                     "returned_match_count": 2,
                     "top_score": 7.5,
                     "top_match_type": "attachment_chunk",
@@ -2205,6 +2244,7 @@ class SearchBehaviorTests(DbTestCase):
                 {
                     "key": "PARENT2",
                     "title": "Second Paper",
+                    "itemType": "preprint",
                     "returned_match_count": 1,
                     "top_score": 8.0,
                     "top_match_type": "metadata",
@@ -2212,6 +2252,7 @@ class SearchBehaviorTests(DbTestCase):
                 {
                     "key": "PARENT3",
                     "title": "Third Paper",
+                    "itemType": "preprint",
                     "returned_match_count": 0,
                     "top_score": None,
                     "top_match_type": None,
@@ -2226,6 +2267,7 @@ class SearchBehaviorTests(DbTestCase):
         self.assertEqual([row["key"] for row in result["matches"]], ["PARENT2", "PARENT1", "PARENT1"])
         self.assertNotIn("title", result["matches"][0])
         self.assertNotIn("title", result["matches"][1])
+        self.assertNotIn("itemType", result["matches"][0])
 
     def test_search_within_item_caps_large_requested_limits_and_reports_metadata(self):
         docs = [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -133,7 +133,7 @@ class ServerToolTests(unittest.TestCase):
         self.assertIn("abstract text truncated to 500 characters", doc)
         self.assertIn("duplicate parent items", normalized_doc.lower())
         self.assertIn("include_attachments", doc)
-        self.assertIn("invalid `collection_key` / `item_type` filters", doc)
+        self.assertIn("invalid `collection_key` / `item_type` filters or empty queries", normalized_doc)
         self.assertIn(
             "values not present in the current search index return no items plus a warning",
             normalized_doc,
@@ -146,16 +146,15 @@ class ServerToolTests(unittest.TestCase):
     def test_search_within_item_delegates_to_db(self):
         with patch.object(server.db, "search_within_item", return_value='{"matches": []}') as db_mock:
             result = server.search_within_item(
-                item_key="ITEM123",
-                item_keys=["ITEM456"],
+                item_keys=["ITEM123", "ITEM456"],
                 query="transformer attention",
                 limit=5,
             )
 
         self.assertEqual(result, '{"matches": []}')
         db_mock.assert_called_once_with(
-            item_key="ITEM123",
-            item_keys=["ITEM456"],
+            item_key="",
+            item_keys=["ITEM123", "ITEM456"],
             query="transformer attention",
             limit=5,
         )
@@ -163,9 +162,12 @@ class ServerToolTests(unittest.TestCase):
     def test_search_within_item_tool_description_mentions_attachment_chunk_fields(self):
         description = _get_registered_tool("search_within_item").description
 
+        self.assertIn("item_keys", description)
+        self.assertIn("score", description)
+        self.assertIn("match_type", description)
+        self.assertIn("itemType", description)
         self.assertIn("attachment_key", description)
         self.assertIn("attachment_title", description)
-        self.assertIn("attachment_filepath", description)
         self.assertIn("chunk_index", description)
         self.assertIn("char_start", description)
         self.assertIn("char_end", description)
@@ -174,6 +176,7 @@ class ServerToolTests(unittest.TestCase):
         self.assertIn("top_match_type", description)
         self.assertIn("requested_limit", description)
         self.assertIn("applied_limit", description)
+        self.assertNotIn("attachment_filepath", description)
 
     def test_response_shape_docstrings_reflect_canonical_keys(self):
         search_within_doc = " ".join(server.search_within_item.__doc__.split())
@@ -183,6 +186,10 @@ class ServerToolTests(unittest.TestCase):
         self.assertIn("under `items`", server.search_library.__doc__)
         self.assertIn("`returned_count`", server.search_library.__doc__)
         self.assertIn("`matches`", server.search_within_item.__doc__)
+        self.assertIn("`item_keys`", server.search_within_item.__doc__)
+        self.assertIn("`score`", server.search_within_item.__doc__)
+        self.assertIn("`match_type`", server.search_within_item.__doc__)
+        self.assertIn("`itemType`", server.search_within_item.__doc__)
         self.assertIn("attachment_key", server.search_within_item.__doc__)
         self.assertIn("`returned_match_count`", server.search_within_item.__doc__)
         self.assertIn("`top_score`", server.search_within_item.__doc__)
@@ -199,6 +206,8 @@ class ServerToolTests(unittest.TestCase):
         self.assertIn("Single-key requests return JSON", get_item_doc)
         self.assertIn("`item_keys`, `items`, `requested`, `total`", get_item_doc)
         self.assertIn("collections as `{key, name}` pairs", get_item_doc)
+        self.assertNotIn("attachment_filepath", search_within_doc)
+        self.assertIn("privacy-safe attachment metadata", get_item_doc)
 
     def test_get_item_delegates_to_db(self):
         with patch.object(server.db, "get_item", return_value='{"key": "ITEM123"}') as db_mock:


### PR DESCRIPTION
Closes #123
Closes #126
Closes #129
Closes #132

Summary:
- Move `itemType` into the returned item summaries and slim `search_within_item` matches.
- Remove local attachment file paths from attachment metadata and related outputs.
- Switch the public `search_within_item` tool schema to `item_keys`.
