### PR TITLE
Fix stale collection shape assertion

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1563,7 +1563,10 @@ class SearchBehaviorTests(DbTestCase):
         self.assertEqual(result["total"], 1)
         self.assertEqual(result["returned_count"], 1)
         self.assertEqual([row["key"] for row in result["items"]], ["PARENT2"])
-        self.assertEqual(result["items"][0]["collections"], ["COLL123"])
+        self.assertEqual(
+            result["items"][0]["collections"],
+            [{"key": "COLL123", "name": "Valid Collection"}],
+        )
 
     def test_search_keeps_same_title_items_distinct_without_doi_or_url(self):
         parents = {


### PR DESCRIPTION
## Summary
- update the stale `tests/test_db.py` assertion to match the merged collection object shape
- keep the post-merge search behavior test aligned with the current API contract

## Testing
- uv run python -m unittest discover -s tests -v